### PR TITLE
Feat/auth api#46

### DIFF
--- a/src/main/java/root/git_turl/GitTurlApplication.java
+++ b/src/main/java/root/git_turl/GitTurlApplication.java
@@ -4,10 +4,12 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableAsync
+@EnableScheduling
 public class GitTurlApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/root/git_turl/domain/member/code/AuthErrorCode.java
+++ b/src/main/java/root/git_turl/domain/member/code/AuthErrorCode.java
@@ -1,0 +1,33 @@
+package root.git_turl.domain.member.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import root.git_turl.global.apiPayload.code.BaseErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements BaseErrorCode {
+
+    NO_REFRESH_TOKEN(
+            HttpStatus.NOT_FOUND,
+            "AUTH404_1",
+            "리프레시 토큰이 존재하지 않습니다."
+    ),
+
+    INVALID_REFRESH_TOKEN(
+            HttpStatus.UNAUTHORIZED,
+            "AUTH401_1",
+            "유효하지 않은 리프레시 토큰입니다."
+    ),
+
+    EXPIRED_REFRESH_TOKEN(
+            HttpStatus.UNAUTHORIZED,
+            "AUTH401_2",
+            "만료된 리프레시 토큰입니다."
+    );
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/root/git_turl/domain/member/code/AuthSuccessCode.java
+++ b/src/main/java/root/git_turl/domain/member/code/AuthSuccessCode.java
@@ -1,0 +1,19 @@
+package root.git_turl.domain.member.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import root.git_turl.global.apiPayload.code.BaseSuccessCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthSuccessCode implements BaseSuccessCode {
+
+    TOKEN_REISSUE_OK(HttpStatus.OK,
+            "AUTH200_1",
+            "토큰이 재발급되었습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/root/git_turl/domain/member/code/AuthSuccessCode.java
+++ b/src/main/java/root/git_turl/domain/member/code/AuthSuccessCode.java
@@ -11,7 +11,11 @@ public enum AuthSuccessCode implements BaseSuccessCode {
 
     TOKEN_REISSUE_OK(HttpStatus.OK,
             "AUTH200_1",
-            "토큰이 재발급되었습니다.");
+            "토큰이 재발급되었습니다."),
+
+    LOGOUT_OK(HttpStatus.OK,
+            "AUTH200_2",
+            "로그아웃 되었습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/root/git_turl/domain/member/code/AuthSuccessCode.java
+++ b/src/main/java/root/git_turl/domain/member/code/AuthSuccessCode.java
@@ -15,7 +15,11 @@ public enum AuthSuccessCode implements BaseSuccessCode {
 
     LOGOUT_OK(HttpStatus.OK,
             "AUTH200_2",
-            "로그아웃 되었습니다.");
+            "로그아웃 되었습니다."),
+
+    WITHDRAW_OK(HttpStatus.OK,
+            "AUTH200_3",
+            "회원탈퇴 되었습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/root/git_turl/domain/member/controller/AuthController.java
+++ b/src/main/java/root/git_turl/domain/member/controller/AuthController.java
@@ -26,4 +26,12 @@ public class AuthController implements AuthControllerDocs{
     ) {
         return ApiResponse.onSuccess(AuthSuccessCode.TOKEN_REISSUE_OK, tokenService.reissueTokens(refreshToken, response));
     }
+
+    @PostMapping("/logout")
+    public ApiResponse<Void> logout(
+            @CookieValue(value = "refreshToken", required = false) String refreshToken
+    ) {
+        tokenService.logout(refreshToken);
+        return ApiResponse.onSuccess(AuthSuccessCode.LOGOUT_OK, null);
+    }
 }

--- a/src/main/java/root/git_turl/domain/member/controller/AuthController.java
+++ b/src/main/java/root/git_turl/domain/member/controller/AuthController.java
@@ -1,0 +1,29 @@
+package root.git_turl.domain.member.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import root.git_turl.domain.member.code.AuthSuccessCode;
+import root.git_turl.domain.member.dto.TokenDto;
+import root.git_turl.domain.member.service.TokenService;
+import root.git_turl.global.apiPayload.ApiResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+@Tag(name = "Auth", description = "인증 관련 API")
+public class AuthController implements AuthControllerDocs{
+
+    private final TokenService tokenService;
+
+    @PostMapping("/reissue")
+    public ApiResponse<TokenDto.AccessToken> accessTokenReissue(
+            @CookieValue(value = "refreshToken", required = false) String refreshToken, HttpServletResponse response
+    ) {
+        return ApiResponse.onSuccess(AuthSuccessCode.TOKEN_REISSUE_OK, tokenService.reissueTokens(refreshToken, response));
+    }
+}

--- a/src/main/java/root/git_turl/domain/member/controller/AuthController.java
+++ b/src/main/java/root/git_turl/domain/member/controller/AuthController.java
@@ -1,15 +1,16 @@
 package root.git_turl.domain.member.controller;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import root.git_turl.domain.member.code.AuthSuccessCode;
 import root.git_turl.domain.member.dto.TokenDto;
+import root.git_turl.domain.member.entity.Member;
+import root.git_turl.domain.member.service.MemberService;
 import root.git_turl.domain.member.service.TokenService;
+import root.git_turl.global.annotation.CurrentUser;
 import root.git_turl.global.apiPayload.ApiResponse;
 
 @RestController
@@ -19,6 +20,7 @@ import root.git_turl.global.apiPayload.ApiResponse;
 public class AuthController implements AuthControllerDocs{
 
     private final TokenService tokenService;
+    private final MemberService memberService;
 
     @PostMapping("/reissue")
     public ApiResponse<TokenDto.AccessToken> accessTokenReissue(
@@ -33,5 +35,13 @@ public class AuthController implements AuthControllerDocs{
     ) {
         tokenService.logout(refreshToken);
         return ApiResponse.onSuccess(AuthSuccessCode.LOGOUT_OK, null);
+    }
+
+    @DeleteMapping("/withdraw")
+    public ApiResponse<Void> withdraw(
+            @CurrentUser @Parameter(hidden = true) Member member
+    ) {
+        memberService.withdraw(member);
+        return ApiResponse.onSuccess(AuthSuccessCode.WITHDRAW_OK, null);
     }
 }

--- a/src/main/java/root/git_turl/domain/member/controller/AuthControllerDocs.java
+++ b/src/main/java/root/git_turl/domain/member/controller/AuthControllerDocs.java
@@ -15,4 +15,12 @@ public interface AuthControllerDocs {
     public ApiResponse<TokenDto.AccessToken> accessTokenReissue(
             @CookieValue(value = "refreshToken", required = false) String refreshToken, HttpServletResponse response
     );
+
+    @Operation(
+            summary = "로그아웃",
+            description = "refreshToken이 삭제 되었습니다."
+    )
+    public ApiResponse<Void> logout(
+            @CookieValue(value = "refreshToken", required = false) String refreshToken
+    );
 }

--- a/src/main/java/root/git_turl/domain/member/controller/AuthControllerDocs.java
+++ b/src/main/java/root/git_turl/domain/member/controller/AuthControllerDocs.java
@@ -1,9 +1,12 @@
 package root.git_turl.domain.member.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.bind.annotation.CookieValue;
 import root.git_turl.domain.member.dto.TokenDto;
+import root.git_turl.domain.member.entity.Member;
+import root.git_turl.global.annotation.CurrentUser;
 import root.git_turl.global.apiPayload.ApiResponse;
 
 public interface AuthControllerDocs {
@@ -22,5 +25,13 @@ public interface AuthControllerDocs {
     )
     public ApiResponse<Void> logout(
             @CookieValue(value = "refreshToken", required = false) String refreshToken
+    );
+
+    @Operation(
+            summary = "회원탈퇴",
+            description = "회원 정보가 삭제되었습니다."
+    )
+    public ApiResponse<Void> withdraw(
+            @CurrentUser @Parameter(hidden = true) Member member
     );
 }

--- a/src/main/java/root/git_turl/domain/member/controller/AuthControllerDocs.java
+++ b/src/main/java/root/git_turl/domain/member/controller/AuthControllerDocs.java
@@ -1,0 +1,18 @@
+package root.git_turl.domain.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.bind.annotation.CookieValue;
+import root.git_turl.domain.member.dto.TokenDto;
+import root.git_turl.global.apiPayload.ApiResponse;
+
+public interface AuthControllerDocs {
+
+    @Operation(
+            summary = "토큰 재발급",
+            description = "accessToken을 재발급하고, refreshToken을 갱신합니다."
+    )
+    public ApiResponse<TokenDto.AccessToken> accessTokenReissue(
+            @CookieValue(value = "refreshToken", required = false) String refreshToken, HttpServletResponse response
+    );
+}

--- a/src/main/java/root/git_turl/domain/member/entity/Member.java
+++ b/src/main/java/root/git_turl/domain/member/entity/Member.java
@@ -8,6 +8,7 @@ import root.git_turl.domain.member.enums.TechStack;
 import root.git_turl.domain.report.entity.Report;
 import root.git_turl.global.entity.BaseEntity;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,13 +34,13 @@ public class Member extends BaseEntity {
     @Column(name = "github_name")
     private String githubName;
 
-    @Column(name = "github_id", nullable = false )
+    @Column(name = "github_id")
     private String githubId;
 
-    @Column(name = "social_uid", nullable = false)
+    @Column(name = "social_uid")
     private String socialUid;
 
-    @Column(name = "profile_image", nullable = false)
+    @Column(name = "profile_image")
     private String profileImage;
 
     @Column(name = "job_type")
@@ -54,12 +55,18 @@ public class Member extends BaseEntity {
     @Column(name = "github_access_token")
     private String githubAccessToken;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     @Builder.Default
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<InterestStack> interestStacks = new ArrayList<>();
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Report> reports = new ArrayList<>();
+
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private RefreshToken refreshToken;
 
     public void addInterestStack(TechStack techStack) {
         InterestStack interestStack = InterestStack.builder()
@@ -109,5 +116,27 @@ public class Member extends BaseEntity {
 
     public void updateGithubToken(String token) {
         this.githubAccessToken = token;
+    }
+
+    public void activateMember() {
+        this.status = Status.ACTIVATE;
+    }
+
+    public void inactivateMember() {
+        this.status = Status.INACTIVATE;
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public void deleteMember() {
+        this.status = Status.DELETED;
+        this.nickname = "탈퇴한 사용자"+id;
+        this.socialUid = null;
+        this.email = null;
+        this.profileImage = null;
+        this.githubId = null;
+        this.githubName = null;
+        interestStacks.clear();
+        reports.clear();
+        this.refreshToken = null;
     }
 }

--- a/src/main/java/root/git_turl/domain/member/entity/RefreshToken.java
+++ b/src/main/java/root/git_turl/domain/member/entity/RefreshToken.java
@@ -41,4 +41,8 @@ public class RefreshToken extends BaseEntity {
         this.token = newToken;
         this.expireDate = newExpireDate;
     }
+
+    public boolean isExpired() {
+        return this.expireDate.isBefore(LocalDateTime.now());
+    }
 }

--- a/src/main/java/root/git_turl/domain/member/enums/Status.java
+++ b/src/main/java/root/git_turl/domain/member/enums/Status.java
@@ -1,5 +1,5 @@
 package root.git_turl.domain.member.enums;
 
 public enum Status {
-    ACTIVATE, INACTIVATE
+    ACTIVATE, INACTIVATE, DELETED
 }

--- a/src/main/java/root/git_turl/domain/member/exception/AuthException.java
+++ b/src/main/java/root/git_turl/domain/member/exception/AuthException.java
@@ -1,0 +1,10 @@
+package root.git_turl.domain.member.exception;
+
+import root.git_turl.global.apiPayload.code.BaseErrorCode;
+import root.git_turl.global.apiPayload.exception.GeneralException;
+
+public class AuthException extends GeneralException {
+    public AuthException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/root/git_turl/domain/member/repository/MemberRepository.java
+++ b/src/main/java/root/git_turl/domain/member/repository/MemberRepository.java
@@ -2,9 +2,13 @@ package root.git_turl.domain.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import root.git_turl.domain.member.entity.Member;
+import root.git_turl.domain.member.enums.Status;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findBySocialUid(String socialUid);
+    List<Member> findAllByStatusAndDeletedAtBefore(Status status, LocalDateTime standard);
 }

--- a/src/main/java/root/git_turl/domain/member/repository/RefreshTokenRepository.java
+++ b/src/main/java/root/git_turl/domain/member/repository/RefreshTokenRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByMemberId(Long memberId);
+    Optional<RefreshToken> findByToken(String token);
 }

--- a/src/main/java/root/git_turl/domain/member/service/MemberService.java
+++ b/src/main/java/root/git_turl/domain/member/service/MemberService.java
@@ -9,6 +9,7 @@ import root.git_turl.domain.member.converter.MemberConverter;
 import root.git_turl.domain.member.dto.MemberReqDto;
 import root.git_turl.domain.member.dto.MemberResDto;
 import root.git_turl.domain.member.entity.Member;
+import root.git_turl.domain.member.enums.Status;
 import root.git_turl.domain.member.exception.MemberException;
 import root.git_turl.domain.member.repository.MemberRepository;
 import root.git_turl.global.aws.AwsFileService;
@@ -87,5 +88,12 @@ public class MemberService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
         return MemberConverter.ProfileInfo(member);
+    }
+
+    @Transactional
+    public void withdraw(Member currentMember) {
+        Member member = memberRepository.findById(currentMember.getId())
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+        member.inactivateMember();
     }
 }

--- a/src/main/java/root/git_turl/domain/member/service/TokenService.java
+++ b/src/main/java/root/git_turl/domain/member/service/TokenService.java
@@ -66,4 +66,17 @@ public class TokenService {
 
         return new TokenDto.AccessToken(accessToken);
     }
+
+    //로그아웃
+    @Transactional
+    public void logout(String refreshTokenValue) {
+        if (refreshTokenValue == null) {
+            throw new AuthException(AuthErrorCode.NO_REFRESH_TOKEN);
+        }
+
+        RefreshToken refreshToken = refreshTokenRepository.findByToken(refreshTokenValue)
+                .orElseThrow(() -> new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN));
+
+        refreshTokenRepository.delete(refreshToken);
+    }
 }

--- a/src/main/java/root/git_turl/domain/member/service/TokenService.java
+++ b/src/main/java/root/git_turl/domain/member/service/TokenService.java
@@ -1,13 +1,17 @@
 package root.git_turl.domain.member.service;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import root.git_turl.domain.member.code.AuthErrorCode;
 import root.git_turl.domain.member.dto.TokenDto;
 import root.git_turl.domain.member.entity.Member;
 import root.git_turl.domain.member.entity.RefreshToken;
+import root.git_turl.domain.member.exception.AuthException;
 import root.git_turl.domain.member.repository.MemberRepository;
 import root.git_turl.domain.member.repository.RefreshTokenRepository;
+import root.git_turl.global.security.CookieUtil;
 import root.git_turl.global.security.jwt.JwtUtil;
 
 import java.time.LocalDateTime;
@@ -36,5 +40,30 @@ public class TokenService {
         refreshTokenRepository.save(refreshToken);
 
         return new TokenDto.Tokens(accessToken, refreshTokenValue);
+    }
+
+    // 토큰 재발급
+    @Transactional
+    public TokenDto.AccessToken reissueTokens(String refreshTokenValue, HttpServletResponse response) {
+        if (refreshTokenValue == null) {
+            throw new AuthException(AuthErrorCode.NO_REFRESH_TOKEN);
+        }
+        RefreshToken refreshToken = refreshTokenRepository.findByToken(refreshTokenValue)
+                        .orElseThrow(() -> new AuthException(AuthErrorCode.INVALID_REFRESH_TOKEN));
+
+        if (refreshToken.isExpired()) {
+            refreshTokenRepository.delete(refreshToken);
+            throw new AuthException(AuthErrorCode.EXPIRED_REFRESH_TOKEN);
+        }
+
+        Member member = refreshToken.getMember();
+
+        String newRefreshTokenValue = jwtUtil.createRefreshToken(member);
+        String accessToken = jwtUtil.createAccessToken(member);
+
+        refreshToken.update(newRefreshTokenValue, LocalDateTime.now().plusDays(1));
+        CookieUtil.addCookie(response, "refreshToken", newRefreshTokenValue);
+
+        return new TokenDto.AccessToken(accessToken);
     }
 }

--- a/src/main/java/root/git_turl/global/config/SecurityConfig.java
+++ b/src/main/java/root/git_turl/global/config/SecurityConfig.java
@@ -33,7 +33,8 @@ public class SecurityConfig {
             "/login/oauth2/**",
             "/oauth2/**",
             "/api/v1/members/*/profile",
-            "/api/v1/auth/**",
+            "/api/v1/auth/reissue",
+            "/api/v1/auth/logout",
             "/login/**",
     };
 

--- a/src/main/java/root/git_turl/global/config/SecurityConfig.java
+++ b/src/main/java/root/git_turl/global/config/SecurityConfig.java
@@ -32,7 +32,9 @@ public class SecurityConfig {
             "/v3/api-docs/**",
             "/login/oauth2/**",
             "/oauth2/**",
-            "/api/v1/members/*/profile"
+            "/api/v1/members/*/profile",
+            "/api/v1/auth/**",
+            "/login/**",
     };
 
 

--- a/src/main/java/root/git_turl/global/security/CookieUtil.java
+++ b/src/main/java/root/git_turl/global/security/CookieUtil.java
@@ -2,17 +2,21 @@ package root.git_turl.global.security;
 
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseCookie;
 
 import java.time.Duration;
 
 public class CookieUtil {
     public static void addCookie(HttpServletResponse response, String name, String value) {
-        Cookie cookie = new Cookie(name, value);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-        cookie.setSecure(false);
-        cookie.setMaxAge((int) Duration.ofDays(1).toSeconds());
-        response.addCookie(cookie);
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .httpOnly(true)
+                .secure(true) // HTTPS 필수
+                .path("/")
+                .maxAge(60 * 60 * 24)
+                .sameSite("None")
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
     }
 
     public static void deleteCookie(HttpServletResponse response, String name) {

--- a/src/main/java/root/git_turl/global/security/oauth/CustomOAuthService.java
+++ b/src/main/java/root/git_turl/global/security/oauth/CustomOAuthService.java
@@ -7,7 +7,10 @@ import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import root.git_turl.domain.member.entity.Member;
+import root.git_turl.domain.member.enums.Status;
 import root.git_turl.domain.member.repository.MemberRepository;
+
+import java.time.LocalDateTime;
 import java.util.Map;
 
 @Service
@@ -34,10 +37,15 @@ public class CustomOAuthService extends DefaultOAuth2UserService {
         String name = (String) attributes.get("name");
 
         return memberRepository.findBySocialUid(socialUid)
-                .map(existingMember -> {
-                    existingMember.updateGithubInfo(login, profileImage, name, email);
-                    memberRepository.save(existingMember);
-                    return new OAuthMember(existingMember, false);
+                .map(m -> {
+                    m.updateGithubInfo(login, profileImage, name, email);
+                    if (m.getStatus().equals(Status.INACTIVATE)) {
+                        if (m.getDeletedAt().plusDays(7).isAfter(LocalDateTime.now())) {
+                            m.activateMember();
+                        }
+                    }
+                    memberRepository.save(m);
+                    return new OAuthMember(m, false);
                 })
                 .orElseGet(() -> {
                     Member newMember = Member.builder()
@@ -46,6 +54,7 @@ public class CustomOAuthService extends DefaultOAuth2UserService {
                             .profileImage(profileImage)
                             .email(email)
                             .githubName(name)
+                            .status(Status.ACTIVATE)
                             .build();
 
                     Member savedMember = memberRepository.save(newMember);

--- a/src/main/java/root/git_turl/global/security/oauth/OAuthSuccessHandler.java
+++ b/src/main/java/root/git_turl/global/security/oauth/OAuthSuccessHandler.java
@@ -59,9 +59,7 @@ public class OAuthSuccessHandler implements AuthenticationSuccessHandler {
         String accessToken = tokenDto.getAccessToken();
         String refreshToken = tokenDto.getRefreshToken();
 
-
         CookieUtil.addCookie(response, "refreshToken", refreshToken);
-
 
         if (oAuthMember.isNew()) {
             response.sendRedirect("http://localhost:5173/login/loading?route=signup&token=" + accessToken);

--- a/src/main/java/root/git_turl/global/util/Schedular.java
+++ b/src/main/java/root/git_turl/global/util/Schedular.java
@@ -1,0 +1,36 @@
+package root.git_turl.global.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import root.git_turl.domain.member.entity.Member;
+import root.git_turl.domain.member.enums.Status;
+import root.git_turl.domain.member.repository.MemberRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class Schedular {
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 16 18 * * *")
+    public void deleteInactiveMembers() {
+
+        LocalDateTime standard = LocalDateTime.now().minusDays(7);
+
+        List<Member> members =
+                memberRepository
+                        .findAllByStatusAndDeletedAtBefore(
+                                Status.INACTIVATE,
+                                standard
+                        );
+
+        for (Member m : members) {
+            m.deleteMember();
+        }
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -29,7 +29,7 @@ spring:
             scope:
               - read:user
               - user:email
-            redirect-uri: "{s/login/oauth2/code/{registrationId}"
+            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
 
 jwt:
   token:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -29,7 +29,7 @@ spring:
             scope:
               - read:user
               - user:email
-            redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
+            redirect-uri: "{s/login/oauth2/code/{registrationId}"
 
 jwt:
   token:


### PR DESCRIPTION
## 💡 관련 이슈
close #46

<br>

## 📝 작업 내용
- 토큰 재발급 api
Cookie에 있는 refreshToken이 유효할 시 accessToken과 refreshToken을 재발급
- 로그아웃 api
refreshToken을 삭제 (accessToken은 프론트 로컬 스토리지에서 삭제)
- 회원탈퇴 api
     기본 상태 : ACTIVATE
     처음 탈퇴 시 : INAVTIVATE (Soft delete, 일주일 내 재가입 시 계정복구 가능)
     탈퇴 후 일주일 뒤 :  DELETE (Hard delete, 커뮤니티 제외 개인 기록 삭제, 복구 불가)
https://velog.io/@icebox127/Spring-Schedular-%EC%9D%B4%EC%9A%A9%ED%95%98%EC%97%AC-hard-delete-%EA%B5%AC%ED%98%84-Scheduled

## 🛠️ 기타
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
