### PR TITLE
Feat: 질문 관련 api 구현

### DIFF
--- a/src/main/java/root/git_turl/domain/member/entity/Member.java
+++ b/src/main/java/root/git_turl/domain/member/entity/Member.java
@@ -5,6 +5,7 @@ import lombok.*;
 import root.git_turl.domain.member.enums.JobType;
 import root.git_turl.domain.member.enums.Status;
 import root.git_turl.domain.member.enums.TechStack;
+import root.git_turl.domain.question.entity.Question;
 import root.git_turl.domain.report.entity.Report;
 import root.git_turl.global.entity.BaseEntity;
 
@@ -67,6 +68,9 @@ public class Member extends BaseEntity {
 
     @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private RefreshToken refreshToken;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Question> questions = new ArrayList<>();
 
     public void addInterestStack(TechStack techStack) {
         InterestStack interestStack = InterestStack.builder()

--- a/src/main/java/root/git_turl/domain/question/controller/QuestionController.java
+++ b/src/main/java/root/git_turl/domain/question/controller/QuestionController.java
@@ -44,4 +44,12 @@ public class QuestionController implements QuestionControllerDocs{
         ReportResDto.Pagination<QuestionResDto.QuestionInfo> response = questionService.getQuestionList(reportId, pageSize, cursor);
         return ApiResponse.onSuccess(QuestionSuccessCode.QUESTION_LIST_GET_OK, response);
     }
+
+    @DeleteMapping("/questions/{questionId}")
+    public ApiResponse<Void> deleteQuestion(
+            @PathVariable Long questionId
+    ) {
+        questionService.deleteQuestion(questionId);
+        return ApiResponse.onSuccess(QuestionSuccessCode.QUESTION_DELETE_OK, null);
+    }
 }

--- a/src/main/java/root/git_turl/domain/question/controller/QuestionController.java
+++ b/src/main/java/root/git_turl/domain/question/controller/QuestionController.java
@@ -7,10 +7,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import root.git_turl.domain.member.entity.Member;
 import root.git_turl.domain.question.dto.QuestionReqDto;
+import root.git_turl.domain.question.dto.QuestionResDto;
 import root.git_turl.domain.question.exception.code.QuestionSuccessCode;
 import root.git_turl.domain.question.service.QuestionService;
+import root.git_turl.domain.report.dto.ReportResDto;
 import root.git_turl.global.annotation.CurrentUser;
 import root.git_turl.global.apiPayload.ApiResponse;
+import root.git_turl.global.util.Pagination;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,5 +33,15 @@ public class QuestionController implements QuestionControllerDocs{
     ) {
         questionService.saveQuestion(member, reportId, dto);
         return ApiResponse.onSuccess(QuestionSuccessCode.QUESTION_POST_OK, null);
+    }
+
+    @GetMapping("/reports/{reportId}/questions")
+    public ApiResponse<ReportResDto.Pagination<QuestionResDto.QuestionInfo>> getQuestions(
+            @PathVariable Long reportId,
+            @RequestParam(required = false) Integer pageSize,
+            @RequestParam(required = false) String cursor
+    ) {
+        ReportResDto.Pagination<QuestionResDto.QuestionInfo> response = questionService.getQuestionList(reportId, pageSize, cursor);
+        return ApiResponse.onSuccess(QuestionSuccessCode.QUESTION_LIST_GET_OK, response);
     }
 }

--- a/src/main/java/root/git_turl/domain/question/controller/QuestionController.java
+++ b/src/main/java/root/git_turl/domain/question/controller/QuestionController.java
@@ -1,0 +1,14 @@
+package root.git_turl.domain.question.controller;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+@Tag(name = "Question", description = "질문 관련 API")
+public class QuestionController {
+
+}

--- a/src/main/java/root/git_turl/domain/question/controller/QuestionController.java
+++ b/src/main/java/root/git_turl/domain/question/controller/QuestionController.java
@@ -1,14 +1,32 @@
 package root.git_turl.domain.question.controller;
 
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import root.git_turl.domain.member.entity.Member;
+import root.git_turl.domain.question.dto.QuestionReqDto;
+import root.git_turl.domain.question.exception.code.QuestionSuccessCode;
+import root.git_turl.domain.question.service.QuestionService;
+import root.git_turl.global.annotation.CurrentUser;
+import root.git_turl.global.apiPayload.ApiResponse;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1")
 @Tag(name = "Question", description = "질문 관련 API")
-public class QuestionController {
+public class QuestionController implements QuestionControllerDocs{
 
+    private final QuestionService questionService;
+
+    @PostMapping("/reports/{reportId}/questions")
+    public ApiResponse<Void> saveQuestion(
+            @CurrentUser @Parameter(hidden = true) Member member,
+            @PathVariable Long reportId,
+            @RequestBody @Valid QuestionReqDto.QuestionCount dto
+    ) {
+        questionService.saveQuestion(member, reportId, dto);
+        return ApiResponse.onSuccess(QuestionSuccessCode.QUESTION_POST_OK, null);
+    }
 }

--- a/src/main/java/root/git_turl/domain/question/controller/QuestionControllerDocs.java
+++ b/src/main/java/root/git_turl/domain/question/controller/QuestionControllerDocs.java
@@ -5,10 +5,16 @@ import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import root.git_turl.domain.member.entity.Member;
 import root.git_turl.domain.question.dto.QuestionReqDto;
+import root.git_turl.domain.question.dto.QuestionResDto;
+import root.git_turl.domain.report.dto.ReportResDto;
 import root.git_turl.global.annotation.CurrentUser;
 import root.git_turl.global.apiPayload.ApiResponse;
+import root.git_turl.global.util.Pagination;
+
+import java.util.List;
 
 public interface QuestionControllerDocs {
 
@@ -20,5 +26,15 @@ public interface QuestionControllerDocs {
             @CurrentUser @Parameter(hidden = true) Member member,
             @PathVariable Long reportId,
             @RequestBody @Valid QuestionReqDto.QuestionCount dto
+    );
+
+    @Operation(
+            summary = "질문 목록 조회",
+            description = "해당 분석본에 대한 질문 목록을 조회합니다."
+    )
+    public ApiResponse<ReportResDto.Pagination<QuestionResDto.QuestionInfo>> getQuestions(
+            @PathVariable Long reportId,
+            @RequestParam(required = false) Integer pageSize,
+            @RequestParam(required = false) String cursor
     );
 }

--- a/src/main/java/root/git_turl/domain/question/controller/QuestionControllerDocs.java
+++ b/src/main/java/root/git_turl/domain/question/controller/QuestionControllerDocs.java
@@ -1,0 +1,4 @@
+package root.git_turl.domain.question.controller;
+
+public interface QuestionControllerDocs {
+}

--- a/src/main/java/root/git_turl/domain/question/controller/QuestionControllerDocs.java
+++ b/src/main/java/root/git_turl/domain/question/controller/QuestionControllerDocs.java
@@ -1,4 +1,24 @@
 package root.git_turl.domain.question.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import root.git_turl.domain.member.entity.Member;
+import root.git_turl.domain.question.dto.QuestionReqDto;
+import root.git_turl.global.annotation.CurrentUser;
+import root.git_turl.global.apiPayload.ApiResponse;
+
 public interface QuestionControllerDocs {
+
+    @Operation(
+            summary = "분석본 토대로 질문 생성",
+            description = "해당 분석본을 토대로 질문을 생성합니다."
+    )
+    public ApiResponse<Void> saveQuestion(
+            @CurrentUser @Parameter(hidden = true) Member member,
+            @PathVariable Long reportId,
+            @RequestBody @Valid QuestionReqDto.QuestionCount dto
+    );
 }

--- a/src/main/java/root/git_turl/domain/question/controller/QuestionControllerDocs.java
+++ b/src/main/java/root/git_turl/domain/question/controller/QuestionControllerDocs.java
@@ -37,4 +37,12 @@ public interface QuestionControllerDocs {
             @RequestParam(required = false) Integer pageSize,
             @RequestParam(required = false) String cursor
     );
+
+    @Operation(
+            summary = "질문 삭제",
+            description = "해당 질문을 삭제합니다."
+    )
+    public ApiResponse<Void> deleteQuestion(
+            @PathVariable Long questionId
+    );
 }

--- a/src/main/java/root/git_turl/domain/question/converter/QuestionConverter.java
+++ b/src/main/java/root/git_turl/domain/question/converter/QuestionConverter.java
@@ -25,6 +25,7 @@ public class QuestionConverter {
                 .questionId(question.getId())
                 .content(question.getContent())
                 .createdAt(question.getCreatedAt().toLocalDate())
+                .status(question.getStatus())
                 .build();
     }
 }

--- a/src/main/java/root/git_turl/domain/question/converter/QuestionConverter.java
+++ b/src/main/java/root/git_turl/domain/question/converter/QuestionConverter.java
@@ -1,6 +1,7 @@
 package root.git_turl.domain.question.converter;
 
 import root.git_turl.domain.member.entity.Member;
+import root.git_turl.domain.question.dto.QuestionResDto;
 import root.git_turl.domain.question.entity.Question;
 import root.git_turl.domain.report.entity.Report;
 
@@ -14,6 +15,16 @@ public class QuestionConverter {
         return Question.builder()
                 .report(report)
                 .member(member)
+                .build();
+    }
+
+    public static QuestionResDto.QuestionInfo toQuestionInfo(
+            Question question
+    ) {
+        return QuestionResDto.QuestionInfo.builder()
+                .questionId(question.getId())
+                .content(question.getContent())
+                .createdAt(question.getCreatedAt().toLocalDate())
                 .build();
     }
 }

--- a/src/main/java/root/git_turl/domain/question/converter/QuestionConverter.java
+++ b/src/main/java/root/git_turl/domain/question/converter/QuestionConverter.java
@@ -1,0 +1,19 @@
+package root.git_turl.domain.question.converter;
+
+import root.git_turl.domain.member.entity.Member;
+import root.git_turl.domain.question.entity.Question;
+import root.git_turl.domain.report.entity.Report;
+
+public class QuestionConverter {
+
+    public static Question toQuestion(
+        Report report,
+        Member member
+
+    ) {
+        return Question.builder()
+                .report(report)
+                .member(member)
+                .build();
+    }
+}

--- a/src/main/java/root/git_turl/domain/question/dto/QuestionContent.java
+++ b/src/main/java/root/git_turl/domain/question/dto/QuestionContent.java
@@ -1,0 +1,12 @@
+package root.git_turl.domain.question.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class QuestionContent {
+    public List<String> questions;
+}

--- a/src/main/java/root/git_turl/domain/question/dto/QuestionReqDto.java
+++ b/src/main/java/root/git_turl/domain/question/dto/QuestionReqDto.java
@@ -1,0 +1,17 @@
+package root.git_turl.domain.question.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+public class QuestionReqDto {
+
+    @Getter
+    public static class QuestionCount {
+        @NotNull
+        @Min(1)
+        @Max(5)
+        private Integer questionCount;
+    }
+}

--- a/src/main/java/root/git_turl/domain/question/dto/QuestionResDto.java
+++ b/src/main/java/root/git_turl/domain/question/dto/QuestionResDto.java
@@ -1,0 +1,17 @@
+package root.git_turl.domain.question.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+public class QuestionResDto {
+
+    @Getter
+    @Builder
+    public static class QuestionInfo{
+        private Long questionId;
+        private String content;
+        private LocalDate createdAt;
+    }
+}

--- a/src/main/java/root/git_turl/domain/question/dto/QuestionResDto.java
+++ b/src/main/java/root/git_turl/domain/question/dto/QuestionResDto.java
@@ -2,6 +2,7 @@ package root.git_turl.domain.question.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import root.git_turl.domain.report.enums.GenerationStatus;
 
 import java.time.LocalDate;
 
@@ -13,5 +14,6 @@ public class QuestionResDto {
         private Long questionId;
         private String content;
         private LocalDate createdAt;
+        private GenerationStatus status;
     }
 }

--- a/src/main/java/root/git_turl/domain/question/entity/Question.java
+++ b/src/main/java/root/git_turl/domain/question/entity/Question.java
@@ -7,6 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import root.git_turl.domain.member.entity.Member;
 import root.git_turl.domain.report.entity.Report;
+import root.git_turl.domain.report.enums.GenerationStatus;
+import root.git_turl.domain.report.enums.Status;
 import root.git_turl.global.entity.BaseEntity;
 
 @Entity
@@ -24,6 +26,11 @@ public class Question extends BaseEntity {
     @Column(name = "content")
     private String content;
 
+    @Builder.Default
+    @Column(name = "status")
+    @Enumerated(EnumType.STRING)
+    private GenerationStatus status = GenerationStatus.PROCESSING;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "report_id")
     private Report report;
@@ -31,4 +38,12 @@ public class Question extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public void updateStatus(GenerationStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/root/git_turl/domain/question/entity/Question.java
+++ b/src/main/java/root/git_turl/domain/question/entity/Question.java
@@ -1,0 +1,34 @@
+package root.git_turl.domain.question.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import root.git_turl.domain.member.entity.Member;
+import root.git_turl.domain.report.entity.Report;
+import root.git_turl.global.entity.BaseEntity;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "question")
+public class Question extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "content")
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "report_id")
+    private Report report;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/root/git_turl/domain/question/exception/QuestionException.java
+++ b/src/main/java/root/git_turl/domain/question/exception/QuestionException.java
@@ -1,0 +1,10 @@
+package root.git_turl.domain.question.exception;
+
+import root.git_turl.global.apiPayload.code.BaseErrorCode;
+import root.git_turl.global.apiPayload.exception.GeneralException;
+
+public class QuestionException extends GeneralException {
+    public QuestionException(BaseErrorCode code) {
+        super(code);
+    }
+}

--- a/src/main/java/root/git_turl/domain/question/exception/code/QuestionErrorCode.java
+++ b/src/main/java/root/git_turl/domain/question/exception/code/QuestionErrorCode.java
@@ -1,0 +1,19 @@
+package root.git_turl.domain.question.exception.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import root.git_turl.global.apiPayload.code.BaseErrorCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum QuestionErrorCode implements BaseErrorCode {
+
+    NOT_FOUND(HttpStatus.NOT_FOUND,
+            "QUESTION404_1",
+            "존재하지 않는 질문입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/root/git_turl/domain/question/exception/code/QuestionSuccessCode.java
+++ b/src/main/java/root/git_turl/domain/question/exception/code/QuestionSuccessCode.java
@@ -1,0 +1,19 @@
+package root.git_turl.domain.question.exception.code;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import root.git_turl.global.apiPayload.code.BaseSuccessCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum QuestionSuccessCode implements BaseSuccessCode {
+
+    QUESTION_POST_OK(HttpStatus.OK,
+            "QUESTION200_2",
+            "질문을 생성하였습니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/root/git_turl/domain/question/exception/code/QuestionSuccessCode.java
+++ b/src/main/java/root/git_turl/domain/question/exception/code/QuestionSuccessCode.java
@@ -9,6 +9,10 @@ import root.git_turl.global.apiPayload.code.BaseSuccessCode;
 @RequiredArgsConstructor
 public enum QuestionSuccessCode implements BaseSuccessCode {
 
+    QUESTION_LIST_GET_OK(HttpStatus.OK,
+            "QUESTION200_1",
+            "질문 목록이 조회되었습니다."),
+
     QUESTION_POST_OK(HttpStatus.OK,
             "QUESTION200_2",
             "질문을 생성하였습니다.");

--- a/src/main/java/root/git_turl/domain/question/exception/code/QuestionSuccessCode.java
+++ b/src/main/java/root/git_turl/domain/question/exception/code/QuestionSuccessCode.java
@@ -15,7 +15,11 @@ public enum QuestionSuccessCode implements BaseSuccessCode {
 
     QUESTION_POST_OK(HttpStatus.OK,
             "QUESTION200_2",
-            "질문을 생성하였습니다.");
+            "질문을 생성하였습니다."),
+
+    QUESTION_DELETE_OK(HttpStatus.OK,
+            "QUESTION200_3",
+            "질문이 삭제되었습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/root/git_turl/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/root/git_turl/domain/question/repository/QuestionRepository.java
@@ -1,0 +1,7 @@
+package root.git_turl.domain.question.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import root.git_turl.domain.question.entity.Question;
+
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+}

--- a/src/main/java/root/git_turl/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/root/git_turl/domain/question/repository/QuestionRepository.java
@@ -3,5 +3,7 @@ package root.git_turl.domain.question.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import root.git_turl.domain.question.entity.Question;
 
+import java.util.Optional;
+
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 }

--- a/src/main/java/root/git_turl/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/root/git_turl/domain/question/repository/QuestionRepository.java
@@ -1,9 +1,11 @@
 package root.git_turl.domain.question.repository;
 
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import root.git_turl.domain.question.entity.Question;
 
-import java.util.Optional;
-
 public interface QuestionRepository extends JpaRepository<Question, Long> {
+    Slice<Question> findQuestionByReport_IdAndIdLessThanOrderByIdDesc(Long reportId, Long idCursor, PageRequest pageRequest);
+    Slice<Question> findQuestionByReport_IdOrderByIdDesc(Long reportId, PageRequest pageRequest);
 }

--- a/src/main/java/root/git_turl/domain/question/service/AsyncQuestionService.java
+++ b/src/main/java/root/git_turl/domain/question/service/AsyncQuestionService.java
@@ -1,0 +1,53 @@
+package root.git_turl.domain.question.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import root.git_turl.domain.question.converter.QuestionConverter;
+import root.git_turl.domain.question.dto.QuestionContent;
+import root.git_turl.domain.question.entity.Question;
+import root.git_turl.domain.question.exception.QuestionException;
+import root.git_turl.domain.question.exception.code.QuestionErrorCode;
+import root.git_turl.domain.question.repository.QuestionRepository;
+import root.git_turl.domain.report.code.ReportErrorCode;
+import root.git_turl.domain.report.entity.Report;
+import root.git_turl.domain.report.enums.GenerationStatus;
+import root.git_turl.domain.report.exception.ReportException;
+import root.git_turl.domain.report.repository.ReportRepository;
+import root.git_turl.global.util.BuildPrompt;
+import root.git_turl.infrastructure.openai.GptService;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AsyncQuestionService {
+
+    private final BuildPrompt buildPrompt;
+    private final ReportRepository reportRepository;
+    private final GptService gptService;
+    private final QuestionRepository questionRepository;
+
+    @Async
+    @Transactional
+    public void makeQuestion(Long reportId, Integer count, List<Long> questionIdLists) {
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new ReportException(ReportErrorCode.REPORT_NOT_FOUND));
+        List<Question> questions =
+                questionRepository.findAllById(questionIdLists);
+        try {
+            String prompt = buildPrompt.buildQuestionPrompt(report, count);
+            List<String> contents = gptService.makeQuestions(prompt).getQuestions();
+
+            for (int i=0; i<questions.size(); i++) {
+                questions.get(i).updateContent(contents.get(i));
+                questions.get(i).updateStatus(GenerationStatus.DONE);
+            }
+        } catch (Exception e) {
+            for (int i=0; i<count; i++) {
+                questions.get(i).updateStatus(GenerationStatus.FAIL);
+            }
+        }
+    }
+}

--- a/src/main/java/root/git_turl/domain/question/service/QuestionService.java
+++ b/src/main/java/root/git_turl/domain/question/service/QuestionService.java
@@ -1,0 +1,47 @@
+package root.git_turl.domain.question.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import root.git_turl.domain.member.code.MemberErrorCode;
+import root.git_turl.domain.member.entity.Member;
+import root.git_turl.domain.member.exception.MemberException;
+import root.git_turl.domain.member.repository.MemberRepository;
+import root.git_turl.domain.question.converter.QuestionConverter;
+import root.git_turl.domain.question.dto.QuestionContent;
+import root.git_turl.domain.question.dto.QuestionReqDto;
+import root.git_turl.domain.question.entity.Question;
+import root.git_turl.domain.question.repository.QuestionRepository;
+import root.git_turl.domain.report.code.ReportErrorCode;
+import root.git_turl.domain.report.entity.Report;
+import root.git_turl.domain.report.exception.ReportException;
+import root.git_turl.domain.report.repository.ReportRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionService {
+
+    private final ReportRepository reportRepository;
+    private final MemberRepository memberRepository;
+    private final QuestionRepository questionRepository;
+    private final AsyncQuestionService asyncQuestionService;
+
+    @Transactional
+    public void saveQuestion(Member currentMember, Long reportId, QuestionReqDto.QuestionCount dto) {
+        Report report = reportRepository.findById(reportId)
+                .orElseThrow(() -> new ReportException(ReportErrorCode.REPORT_NOT_FOUND));
+        Member member = memberRepository.findById(currentMember.getId())
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+
+        List<Question> questions = new ArrayList<>();
+        for (int i=0; i<dto.getQuestionCount(); i++) {
+            Question question = QuestionConverter.toQuestion(report, member);
+            questions.add(question);
+        }
+        questionRepository.saveAll(questions);
+        asyncQuestionService.makeQuestion(reportId, dto.getQuestionCount(), questions.stream().map(Question::getId).toList());
+    }
+}

--- a/src/main/java/root/git_turl/domain/question/service/QuestionService.java
+++ b/src/main/java/root/git_turl/domain/question/service/QuestionService.java
@@ -1,6 +1,8 @@
 package root.git_turl.domain.question.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import root.git_turl.domain.member.code.MemberErrorCode;
@@ -10,12 +12,15 @@ import root.git_turl.domain.member.repository.MemberRepository;
 import root.git_turl.domain.question.converter.QuestionConverter;
 import root.git_turl.domain.question.dto.QuestionContent;
 import root.git_turl.domain.question.dto.QuestionReqDto;
+import root.git_turl.domain.question.dto.QuestionResDto;
 import root.git_turl.domain.question.entity.Question;
 import root.git_turl.domain.question.repository.QuestionRepository;
 import root.git_turl.domain.report.code.ReportErrorCode;
+import root.git_turl.domain.report.dto.ReportResDto;
 import root.git_turl.domain.report.entity.Report;
 import root.git_turl.domain.report.exception.ReportException;
 import root.git_turl.domain.report.repository.ReportRepository;
+import root.git_turl.global.util.Pagination;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -43,5 +48,39 @@ public class QuestionService {
         }
         questionRepository.saveAll(questions);
         asyncQuestionService.makeQuestion(reportId, dto.getQuestionCount(), questions.stream().map(Question::getId).toList());
+    }
+
+    public ReportResDto.Pagination<QuestionResDto.QuestionInfo> getQuestionList(
+            Long reportId,
+            Integer pageSize,
+            String cursor
+    ) {
+        if (pageSize == null) pageSize = 10;
+        if (cursor == null) cursor = "-1";
+
+        PageRequest pageRequest = PageRequest.of(0, pageSize);
+
+        long idCursor;
+        Slice<Question> questionList;
+        String nextCursor;
+
+        if (!cursor.equals("-1")) {
+            idCursor = Long.parseLong(cursor);
+            questionList = questionRepository.findQuestionByReport_IdAndIdLessThanOrderByIdDesc(reportId, idCursor, pageRequest);
+        } else {
+            questionList = questionRepository.findQuestionByReport_IdOrderByIdDesc(reportId, pageRequest);
+        }
+
+        nextCursor = questionList.getContent().getLast().getId().toString();
+
+        return Pagination.toPagination(
+                questionList
+                        .stream()
+                        .map(QuestionConverter::toQuestionInfo)
+                        .toList(),
+                questionList.hasNext(),
+                nextCursor,
+                questionList.getSize()
+        );
     }
 }

--- a/src/main/java/root/git_turl/domain/question/service/QuestionService.java
+++ b/src/main/java/root/git_turl/domain/question/service/QuestionService.java
@@ -14,6 +14,8 @@ import root.git_turl.domain.question.dto.QuestionContent;
 import root.git_turl.domain.question.dto.QuestionReqDto;
 import root.git_turl.domain.question.dto.QuestionResDto;
 import root.git_turl.domain.question.entity.Question;
+import root.git_turl.domain.question.exception.QuestionException;
+import root.git_turl.domain.question.exception.code.QuestionErrorCode;
 import root.git_turl.domain.question.repository.QuestionRepository;
 import root.git_turl.domain.report.code.ReportErrorCode;
 import root.git_turl.domain.report.dto.ReportResDto;
@@ -82,5 +84,13 @@ public class QuestionService {
                 nextCursor,
                 questionList.getSize()
         );
+    }
+
+    @Transactional
+    public void deleteQuestion(Long questionId) {
+        Question question = questionRepository.findById(questionId)
+                .orElseThrow(() -> new QuestionException(QuestionErrorCode.NOT_FOUND));
+
+        questionRepository.delete(question);
     }
 }

--- a/src/main/java/root/git_turl/domain/report/entity/Report.java
+++ b/src/main/java/root/git_turl/domain/report/entity/Report.java
@@ -3,9 +3,13 @@ package root.git_turl.domain.report.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import root.git_turl.domain.member.entity.Member;
+import root.git_turl.domain.question.entity.Question;
 import root.git_turl.domain.report.enums.GenerationStatus;
 import root.git_turl.domain.report.enums.Status;
 import root.git_turl.global.entity.BaseEntity;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Builder
@@ -50,6 +54,8 @@ public class Report extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    @OneToMany(mappedBy = "report")
+    private List<Question> questions = new ArrayList<>();
 
     public void updateTitle(String title) { this.title = title; }
 

--- a/src/main/java/root/git_turl/global/util/BuildPrompt.java
+++ b/src/main/java/root/git_turl/global/util/BuildPrompt.java
@@ -3,6 +3,7 @@ package root.git_turl.global.util;
 import org.springframework.stereotype.Component;
 import root.git_turl.domain.report.dto.GitAnalysisResult;
 import root.git_turl.domain.report.dto.commit.MajorCommit;
+import root.git_turl.domain.report.entity.Report;
 
 @Component
 public class BuildPrompt {
@@ -115,6 +116,30 @@ public class BuildPrompt {
                 "    - title: 개선할 점 제목 (예: 공통 응답 처리)\n" +
                 "    - content: 분석 내용 (2문장 이상)\n" +
                 "\n");
+
+        return sb.toString();
+    }
+
+    public String buildQuestionPrompt(Report report, Integer questionCount) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("다음은 한 개발자의 Github repository 분석본입니다. \n");
+        sb.append(report.getContentJson());
+        sb.append("\n 해당 분석본을 읽고, 아래 기준을 참고하여 적절한 개발자 면접 질문을 %d개 생성하세요." .formatted(questionCount));
+        sb.append("\n레포 연관성:t레포의 특정 코드, 기능, 설계 의도에서 직접 도출된 질문임.\n");
+        sb.append("면접 적합성: 실제 기술면접에서 물어볼 만한 수준이며, 지원자의 사고 과정을 확인할 수 있음.");
+        sb.append("""
+            반드시 아래 JSON 형식으로만 응답하세요.
+            설명, 마크다운, 번호, 코드블록 없이 JSON만 반환하세요.
+            
+            {
+              "questions": [
+                "질문1",
+                "질문2",
+                "질문3"
+              ]
+            }
+        """);
 
         return sb.toString();
     }

--- a/src/main/java/root/git_turl/infrastructure/openai/GptService.java
+++ b/src/main/java/root/git_turl/infrastructure/openai/GptService.java
@@ -10,11 +10,13 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+import root.git_turl.domain.question.dto.QuestionContent;
 import root.git_turl.domain.report.dto.gpt.GptMessage;
 import root.git_turl.domain.report.dto.gpt.GptRequest;
 import root.git_turl.domain.report.dto.gpt.GptResponse;
 import root.git_turl.domain.report.dto.reportDetail.ReportContent;
 import root.git_turl.domain.report.dto.reportDetail.ReportWrapper;
+import root.git_turl.domain.report.entity.Report;
 
 import java.util.List;
 
@@ -28,7 +30,14 @@ public class GptService {
     public String openAiApiKey;
 
     public ReportWrapper analyzeGit(String prompt) {
+        return requestGpt(prompt, ReportWrapper.class);
+    }
 
+    public QuestionContent makeQuestions(String prompt) {
+        return requestGpt(prompt, QuestionContent.class);
+    }
+
+    private <T> T requestGpt(String prompt, Class<T> classType) {
         GptRequest request = new GptRequest();
         request.setMessages(List.of(
                 GptMessage.builder()
@@ -52,7 +61,7 @@ public class GptService {
 
         String json = response.getBody().getChoices().get(0).getMessage().getContent();
         try {
-            return objectMapper.readValue(json, ReportWrapper.class);
+            return objectMapper.readValue(json, classType);
         } catch (JsonProcessingException e) {
             throw new RuntimeException("GPT 응답 파싱 실패: " + json, e);
         }


### PR DESCRIPTION
## 💡 관련 이슈
#49

<br>

## 📝 작업 내용
면접 질문 관련 api 구현
- 질문 생성 api
   1~5개의 질문 생성 가능,
   비동기 처리로 빠른 응답
   
<img width="396" height="133" alt="image" src="https://github.com/user-attachments/assets/7b54140c-4cf8-4de3-a9b8-7808e4e3bbaa" />
<img width="811" height="361" alt="image" src="https://github.com/user-attachments/assets/92290457-a789-430f-8e29-52816a3a965b" />

- 질문 목록 조회 api
- 질문 삭제 api

## 🛠️ 기타
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
