### PR TITLE
[Feat] 회원 관련 api 추가구현

### DIFF
--- a/src/main/java/root/git_turl/domain/member/code/MemberErrorCode.java
+++ b/src/main/java/root/git_turl/domain/member/code/MemberErrorCode.java
@@ -21,14 +21,17 @@ public enum MemberErrorCode implements BaseErrorCode {
             "MEMBER400_2",
             "수정 사항이 없습니다."),
 
+    NICKNAME_DUPLICATE(HttpStatus.BAD_REQUEST,
+            "MEMBER400_3",
+            "중복된 닉네임은 사용할 수 없습니다."),
+
     FILE_TYPE_ERROR(HttpStatus.BAD_REQUEST,
                 "FILE400",
                     "이미지 파일만 업로드 가능합니다."),
 
     IMAGE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR,
                 "FILE404",
-                    "프로필 이미지 업로드에 실패하였습니다."
-    );
+                    "프로필 이미지 업로드에 실패하였습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/root/git_turl/domain/member/code/MemberSuccessCode.java
+++ b/src/main/java/root/git_turl/domain/member/code/MemberSuccessCode.java
@@ -21,20 +21,24 @@ public enum MemberSuccessCode implements BaseSuccessCode {
             "MEMBER200_3",
             "프로필 정보를 조회했습니다."),
 
+    HISTORY_GET_OK(HttpStatus.OK,
+            "MEMBER200_4",
+            "히스토리 정보를 조회했습니다."),
+
     PROFILE_IMAGE_GET_OK(HttpStatus.OK,
-            "MEMBER200_6",
+            "MEMBER200_5",
             "프로필 사진이 조회되었습니다."),
 
     PROFILE_IMAGE_PATCH_OK(HttpStatus.OK,
-            "MEMBER200_7",
+            "MEMBER200_6",
             "프로필 사진이 수정되었습니다."),
 
     NICKNAME_CHECK_OK(HttpStatus.OK,
-            "MEMBER200_8",
+            "MEMBER200_7",
             "사용 가능한 닉네임입니다."),
 
     NICKNAME_CHECK_DUPLICATED(HttpStatus.OK,
-            "MEMBER200_9",
+            "MEMBER200_8",
             "사용 할 수 없는 닉네임입니다.");
 
     private final HttpStatus status;

--- a/src/main/java/root/git_turl/domain/member/code/MemberSuccessCode.java
+++ b/src/main/java/root/git_turl/domain/member/code/MemberSuccessCode.java
@@ -27,7 +27,15 @@ public enum MemberSuccessCode implements BaseSuccessCode {
 
     PROFILE_IMAGE_PATCH_OK(HttpStatus.OK,
             "MEMBER200_7",
-            "프로필 사진이 수정되었습니다.");
+            "프로필 사진이 수정되었습니다."),
+
+    NICKNAME_CHECK_OK(HttpStatus.OK,
+            "MEMBER200_8",
+            "사용 가능한 닉네임입니다."),
+
+    NICKNAME_CHECK_DUPLICATED(HttpStatus.OK,
+            "MEMBER200_9",
+            "사용 할 수 없는 닉네임입니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/root/git_turl/domain/member/controller/MemberController.java
+++ b/src/main/java/root/git_turl/domain/member/controller/MemberController.java
@@ -69,4 +69,16 @@ public class MemberController implements MemberControllerDocs{
     ) {
         return ApiResponse.onSuccess(MemberSuccessCode.PROFILE_INFO_GET_OK,  memberService.getMemberProfile(memberId));
     }
+
+    @PostMapping("/nickname")
+    public ApiResponse<Void> nicknameDuplicateCheck(
+            @CurrentUser @Parameter(hidden = true) Member member,
+            @RequestBody @Valid MemberReqDto.Nickname dto
+    ) {
+        boolean isDuplicated = memberService.nicknameDuplicateCheck(member, dto.getNickname());
+        if (isDuplicated) {
+            return ApiResponse.onSuccess(MemberSuccessCode.NICKNAME_CHECK_DUPLICATED, null);
+        }
+        return ApiResponse.onSuccess(MemberSuccessCode.NICKNAME_CHECK_OK, null);
+    }
 }

--- a/src/main/java/root/git_turl/domain/member/controller/MemberController.java
+++ b/src/main/java/root/git_turl/domain/member/controller/MemberController.java
@@ -81,4 +81,12 @@ public class MemberController implements MemberControllerDocs{
         }
         return ApiResponse.onSuccess(MemberSuccessCode.NICKNAME_CHECK_OK, null);
     }
+
+    @GetMapping("/me/history")
+    public ApiResponse<MemberResDto.History> getHistory(
+            @CurrentUser @Parameter(hidden = true) Member member
+    ) {
+        MemberResDto.History response = memberService.getHistory(member);
+        return ApiResponse.onSuccess(MemberSuccessCode.HISTORY_GET_OK, response);
+    }
 }

--- a/src/main/java/root/git_turl/domain/member/controller/MemberControllerDocs.java
+++ b/src/main/java/root/git_turl/domain/member/controller/MemberControllerDocs.java
@@ -76,4 +76,12 @@ public interface MemberControllerDocs {
             @CurrentUser @Parameter(hidden = true) Member member,
             @RequestBody @Valid MemberReqDto.Nickname dto
     );
+
+    @Operation(
+            summary = "깃털 히스토리 조회",
+            description = "깃털 사용 내역을 조회합니다."
+    )
+    public ApiResponse<MemberResDto.History> getHistory(
+            @CurrentUser @Parameter(hidden = true) Member member
+    );
 }

--- a/src/main/java/root/git_turl/domain/member/controller/MemberControllerDocs.java
+++ b/src/main/java/root/git_turl/domain/member/controller/MemberControllerDocs.java
@@ -67,4 +67,13 @@ public interface MemberControllerDocs {
     public ApiResponse<MemberResDto.ProfileInfo> getMemberProfile (
             @PathVariable Long memberId
     );
+
+    @Operation(
+            summary = "닉네임 중복 확인",
+            description = "닉네임 중복 여부를 확인합니다."
+    )
+    public ApiResponse<Void> nicknameDuplicateCheck(
+            @CurrentUser @Parameter(hidden = true) Member member,
+            @RequestBody @Valid MemberReqDto.Nickname dto
+    );
 }

--- a/src/main/java/root/git_turl/domain/member/converter/MemberConverter.java
+++ b/src/main/java/root/git_turl/domain/member/converter/MemberConverter.java
@@ -3,6 +3,9 @@ package root.git_turl.domain.member.converter;
 import root.git_turl.domain.member.dto.MemberResDto;
 import root.git_turl.domain.member.entity.Member;
 
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
 public class MemberConverter {
 
     public static MemberResDto.ProfileImage ProfileImage(
@@ -25,6 +28,18 @@ public class MemberConverter {
                         .stream()
                         .map(interestStack -> interestStack.getTechStack())
                         .toList())
+                .build();
+    }
+
+    public static MemberResDto.History toHistory(
+            Member member,
+            long reportCount,
+            long questionCount
+    ) {
+        return MemberResDto.History.builder()
+                .daysWthGitTurl(ChronoUnit.DAYS.between(member.getCreatedAt().toLocalDate(), LocalDate.now()))
+                .githubReportCount(reportCount)
+                .interviewQuestionCount(questionCount)
                 .build();
     }
 }

--- a/src/main/java/root/git_turl/domain/member/dto/MemberReqDto.java
+++ b/src/main/java/root/git_turl/domain/member/dto/MemberReqDto.java
@@ -42,4 +42,10 @@ public class MemberReqDto {
         private List<TechStack> techStackList;
 
     }
+
+    @Getter
+    public static class Nickname {
+        @Size(max=20)
+        private String nickname;
+    }
 }

--- a/src/main/java/root/git_turl/domain/member/dto/MemberResDto.java
+++ b/src/main/java/root/git_turl/domain/member/dto/MemberResDto.java
@@ -25,4 +25,12 @@ public class MemberResDto {
         private JobType jobType;
         private List<TechStack> techStackList;
     }
+
+    @Getter
+    @Builder
+    public static class History {
+        private Long daysWthGitTurl;
+        private Long githubReportCount;
+        private Long interviewQuestionCount;
+    }
 }

--- a/src/main/java/root/git_turl/domain/member/entity/Member.java
+++ b/src/main/java/root/git_turl/domain/member/entity/Member.java
@@ -81,10 +81,9 @@ public class Member extends BaseEntity {
         interestStack.assignMember(this);
     }
 
-    public void updateGithubInfo(String githubId, String githubName, String profileImage, String email) {
+    public void updateGithubInfo(String githubId, String githubName, String email) {
         this.githubId = githubId;
         this.githubName = githubName;
-        this.profileImage = profileImage;
         this.email = email;
     }
 

--- a/src/main/java/root/git_turl/domain/member/repository/MemberRepository.java
+++ b/src/main/java/root/git_turl/domain/member/repository/MemberRepository.java
@@ -11,4 +11,5 @@ import java.util.Optional;
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findBySocialUid(String socialUid);
     List<Member> findAllByStatusAndDeletedAtBefore(Status status, LocalDateTime standard);
+    Boolean existsByNickname(String nickname);
 }

--- a/src/main/java/root/git_turl/domain/member/service/MemberService.java
+++ b/src/main/java/root/git_turl/domain/member/service/MemberService.java
@@ -55,6 +55,8 @@ public class MemberService {
             throw new MemberException(MemberErrorCode.PROFILE_BAD_REQUEST);
         }
 
+        validateNicknameDuplicate(dto.getNickname());
+
         String email = githubClient.getEmail(currentMember.getGithubAccessToken());
 
         Member member = memberRepository.findById(currentMember.getId())
@@ -69,6 +71,8 @@ public class MemberService {
         if (dto.getNickname() == null && dto.getJobType()==null && dto.getTechStackList()==null) {
             throw new MemberException(MemberErrorCode.NO_EDIT);
         }
+
+        validateNicknameDuplicate(dto.getNickname());
 
         Member member = memberRepository.findById(currentMember.getId())
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
@@ -95,5 +99,20 @@ public class MemberService {
         Member member = memberRepository.findById(currentMember.getId())
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
         member.inactivateMember();
+    }
+
+    @Transactional(readOnly = true)
+    public boolean nicknameDuplicateCheck(Member currentMember, String nickname) {
+        return isNicknameDuplicate(nickname);
+    }
+
+    private void validateNicknameDuplicate(String nickname) {
+        if (isNicknameDuplicate(nickname)) {
+            throw new MemberException(MemberErrorCode.NICKNAME_DUPLICATE);
+        }
+    }
+
+    private boolean isNicknameDuplicate(String nickname) {
+        return memberRepository.existsByNickname(nickname);
     }
 }

--- a/src/main/java/root/git_turl/domain/member/service/MemberService.java
+++ b/src/main/java/root/git_turl/domain/member/service/MemberService.java
@@ -12,6 +12,9 @@ import root.git_turl.domain.member.entity.Member;
 import root.git_turl.domain.member.enums.Status;
 import root.git_turl.domain.member.exception.MemberException;
 import root.git_turl.domain.member.repository.MemberRepository;
+import root.git_turl.domain.question.repository.QuestionRepository;
+import root.git_turl.domain.report.enums.GenerationStatus;
+import root.git_turl.domain.report.repository.ReportRepository;
 import root.git_turl.global.aws.AwsFileService;
 import root.git_turl.infrastructure.github.GithubClient;
 
@@ -24,6 +27,8 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final AwsFileService awsFileService;
     private final GithubClient githubClient;
+    private final ReportRepository reportRepository;
+    private final QuestionRepository questionRepository;
 
     @Transactional(readOnly = true)
     public MemberResDto.ProfileImage getProfileImage(Member member) {
@@ -37,8 +42,7 @@ public class MemberService {
             throw new MemberException(MemberErrorCode.PROFILE_BAD_REQUEST);
         }
 
-        Member member = memberRepository.findById(currentMember.getId())
-                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+        Member member = getMember(currentMember.getId());
 
         try {
             String imageUrl = awsFileService.saveProfileImg(image, member.getId());
@@ -59,8 +63,7 @@ public class MemberService {
 
         String email = githubClient.getEmail(currentMember.getGithubAccessToken());
 
-        Member member = memberRepository.findById(currentMember.getId())
-                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+        Member member = getMember(currentMember.getId());
 
         member.saveProfile(dto.getNickname(), dto.getJobType(), dto.getTechStackList());
         member.setEmail(email);
@@ -74,36 +77,46 @@ public class MemberService {
 
         validateNicknameDuplicate(dto.getNickname());
 
-        Member member = memberRepository.findById(currentMember.getId())
-                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+        Member member = getMember(currentMember.getId());
 
         member.updateProfile(dto.getNickname(), dto.getJobType(), dto.getTechStackList());
     }
 
     @Transactional(readOnly = true)
     public MemberResDto.ProfileInfo getMyProfile(Member currentMember) {
-        Member member = memberRepository.findById(currentMember.getId())
-                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+        Member member = getMember(currentMember.getId());
         return MemberConverter.ProfileInfo(member);
     }
 
     @Transactional(readOnly = true)
     public MemberResDto.ProfileInfo getMemberProfile(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+        Member member = getMember(memberId);
         return MemberConverter.ProfileInfo(member);
     }
 
     @Transactional
     public void withdraw(Member currentMember) {
-        Member member = memberRepository.findById(currentMember.getId())
-                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+        Member member = getMember(currentMember.getId());
         member.inactivateMember();
     }
 
     @Transactional(readOnly = true)
     public boolean nicknameDuplicateCheck(Member currentMember, String nickname) {
         return isNicknameDuplicate(nickname);
+    }
+
+    @Transactional(readOnly = true)
+    public MemberResDto.History getHistory(Member currentMember) {
+        Member member = getMember(currentMember.getId());
+        long reportCount = reportRepository.countByMemberAndGenerationStatus(member, GenerationStatus.DONE);
+        long questionCount = questionRepository.countByMemberAndStatus(member, GenerationStatus.DONE);
+        return MemberConverter.toHistory(member, reportCount, questionCount);
+    }
+
+    private Member getMember(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
+        return member;
     }
 
     private void validateNicknameDuplicate(String nickname) {

--- a/src/main/java/root/git_turl/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/root/git_turl/domain/question/repository/QuestionRepository.java
@@ -3,9 +3,12 @@ package root.git_turl.domain.question.repository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import root.git_turl.domain.member.entity.Member;
 import root.git_turl.domain.question.entity.Question;
+import root.git_turl.domain.report.enums.GenerationStatus;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
     Slice<Question> findQuestionByReport_IdAndIdLessThanOrderByIdDesc(Long reportId, Long idCursor, PageRequest pageRequest);
     Slice<Question> findQuestionByReport_IdOrderByIdDesc(Long reportId, PageRequest pageRequest);
+    long countByMemberAndStatus(Member member, GenerationStatus status);
 }

--- a/src/main/java/root/git_turl/domain/report/repository/ReportRepository.java
+++ b/src/main/java/root/git_turl/domain/report/repository/ReportRepository.java
@@ -3,6 +3,7 @@ package root.git_turl.domain.report.repository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import root.git_turl.domain.member.entity.Member;
 import root.git_turl.domain.report.entity.Report;
 import root.git_turl.domain.report.enums.GenerationStatus;
 import root.git_turl.domain.report.enums.Status;
@@ -37,4 +38,5 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
     Slice<Report> findReportByMember_IdAndGenerationStatusAndStatusOrderByIdDesc(
             Long memberId, GenerationStatus done, Status status, PageRequest pageRequest
     );
+    long countByMemberAndGenerationStatus(Member member, GenerationStatus status);
 }

--- a/src/main/java/root/git_turl/global/security/oauth/CustomOAuthService.java
+++ b/src/main/java/root/git_turl/global/security/oauth/CustomOAuthService.java
@@ -38,7 +38,7 @@ public class CustomOAuthService extends DefaultOAuth2UserService {
 
         return memberRepository.findBySocialUid(socialUid)
                 .map(m -> {
-                    m.updateGithubInfo(login, name, profileImage, email);
+                    m.updateGithubInfo(login, name, email);
                     if (m.getStatus().equals(Status.INACTIVATE)) {
                         if (m.getDeletedAt().plusDays(7).isAfter(LocalDateTime.now())) {
                             m.activateMember();


### PR DESCRIPTION
## 💡 관련 이슈
- close #55

<br>

- 닉네임 중복 조회 api
닉네임 중복도 정상 응답 처리 (각각 다른 응답 메세지 반환) 
의미 상 get이 더 적합하나 nickname을 requestBody로 받아야해서 post로 구현
<img width="302" height="98" alt="image" src="https://github.com/user-attachments/assets/5364f6cd-e05d-4a4d-afea-7fd01be7dd46" />
<img width="282" height="98" alt="image" src="https://github.com/user-attachments/assets/e5a730a7-4d05-4f00-9956-b80aa9f99365" />

- 깃털 히스토리 조회 api
countByMemberAndGenerationStatus를 정의하여 상태가 DONE(완료)인 리포트, 질문 값의 개수 추출
<img width="308" height="149" alt="image" src="https://github.com/user-attachments/assets/b29323a9-95d1-490c-b747-0766e2e9392c" />


<br>

## 🛠️ 기타
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
