### PR TITLE
[Feat] 음성 답변 관련 api 구현

### DIFF
--- a/src/main/java/root/git_turl/domain/answer/controller/AnswerController.java
+++ b/src/main/java/root/git_turl/domain/answer/controller/AnswerController.java
@@ -63,6 +63,15 @@ public class AnswerController implements AnswerControllerDocs{
         return ApiResponse.onSuccess(AnswerSuccessCode.ANSWER_DELETE_OK, null);
     }
 
+    @GetMapping("/questions/{questionId}/answers/voice")
+    public ApiResponse<AnswerResDto.VoiceAnswer> getVoiceAnswer(
+            @CurrentUser @Parameter(hidden = true) Member member,
+            @PathVariable Long questionId
+    ) {
+        AnswerResDto.VoiceAnswer response = answerService.getVoiceAnswer(member, questionId);
+        return ApiResponse.onSuccess(AnswerSuccessCode.ANSWER_LIST_GET_OK, response);
+    }
+
     @PostMapping(value = "/questions/{questionId}/answers/voice", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<Void> saveAnswer(
             @CurrentUser @Parameter(hidden = true) Member member,

--- a/src/main/java/root/git_turl/domain/answer/controller/AnswerController.java
+++ b/src/main/java/root/git_turl/domain/answer/controller/AnswerController.java
@@ -4,7 +4,9 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import root.git_turl.domain.answer.dto.AnswerReqDto;
 import root.git_turl.domain.answer.dto.AnswerResDto;
 import root.git_turl.domain.answer.exception.code.AnswerSuccessCode;
@@ -13,6 +15,7 @@ import root.git_turl.domain.member.entity.Member;
 import root.git_turl.global.annotation.CurrentUser;
 import root.git_turl.global.apiPayload.ApiResponse;
 
+import java.io.File;
 import java.util.List;
 
 @RestController
@@ -58,5 +61,15 @@ public class AnswerController implements AnswerControllerDocs{
     ) {
         answerService.deleteAnswer(member, answerId);
         return ApiResponse.onSuccess(AnswerSuccessCode.ANSWER_DELETE_OK, null);
+    }
+
+    @PostMapping(value = "/questions/{questionId}/answers/voice", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<Void> saveAnswer(
+            @CurrentUser @Parameter(hidden = true) Member member,
+            @PathVariable Long questionId,
+            @RequestPart("file") MultipartFile file
+    ) {
+        answerService.saveAnswerVoice(member, questionId, file);
+        return ApiResponse.onSuccess(AnswerSuccessCode.ANSWER_POST_OK, null);
     }
 }

--- a/src/main/java/root/git_turl/domain/answer/controller/AnswerController.java
+++ b/src/main/java/root/git_turl/domain/answer/controller/AnswerController.java
@@ -72,4 +72,13 @@ public class AnswerController implements AnswerControllerDocs{
         answerService.saveAnswerVoice(member, questionId, file);
         return ApiResponse.onSuccess(AnswerSuccessCode.ANSWER_POST_OK, null);
     }
+
+    @PostMapping("/questions/{questionId}/answers/pass")
+    public ApiResponse<Void> savePass(
+            @CurrentUser @Parameter(hidden = true) Member member,
+            @PathVariable Long questionId
+    ) {
+        answerService.savePass(member, questionId);
+        return ApiResponse.onSuccess(AnswerSuccessCode.ANSWER_PASS_OK, null);
+    }
 }

--- a/src/main/java/root/git_turl/domain/answer/controller/AnswerControllerDocs.java
+++ b/src/main/java/root/git_turl/domain/answer/controller/AnswerControllerDocs.java
@@ -54,6 +54,15 @@ public interface AnswerControllerDocs {
     );
 
     @Operation(
+            summary = "음성 답변&피드백 조회",
+            description = "음성 답변과 피드백을 조회합니다."
+    )
+    public ApiResponse<AnswerResDto.VoiceAnswer> getVoiceAnswer(
+            @CurrentUser @Parameter(hidden = true) Member member,
+            @PathVariable Long questionId
+    );
+
+    @Operation(
             summary = "음성 답변 저장",
             description = "음성 답변을 저장하고, 피드백을 생성합니다."
     )

--- a/src/main/java/root/git_turl/domain/answer/controller/AnswerControllerDocs.java
+++ b/src/main/java/root/git_turl/domain/answer/controller/AnswerControllerDocs.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
 import root.git_turl.domain.answer.dto.AnswerReqDto;
 import root.git_turl.domain.answer.dto.AnswerResDto;
 import root.git_turl.domain.member.entity.Member;
@@ -49,5 +51,15 @@ public interface AnswerControllerDocs {
     public ApiResponse<Void> deleteAnswer(
             @CurrentUser @Parameter(hidden = true) Member member,
             @PathVariable Long answerId
+    );
+
+    @Operation(
+            summary = "음성 답변 저장",
+            description = "음성 답변을 저장하고, 피드백을 생성합니다."
+    )
+    public ApiResponse<Void> saveAnswer(
+            @CurrentUser @Parameter(hidden = true) Member member,
+            @PathVariable Long questionId,
+            @RequestPart("file") MultipartFile file
     );
 }

--- a/src/main/java/root/git_turl/domain/answer/controller/AnswerControllerDocs.java
+++ b/src/main/java/root/git_turl/domain/answer/controller/AnswerControllerDocs.java
@@ -62,4 +62,13 @@ public interface AnswerControllerDocs {
             @PathVariable Long questionId,
             @RequestPart("file") MultipartFile file
     );
+
+    @Operation(
+            summary = "음성 답변 패스",
+            description = "질문에 대한 답변을 저장하지 않습니다."
+    )
+    public ApiResponse<Void> savePass(
+            @CurrentUser @Parameter(hidden = true) Member member,
+            @PathVariable Long questionId
+    );
 }

--- a/src/main/java/root/git_turl/domain/answer/converter/AnswerConverter.java
+++ b/src/main/java/root/git_turl/domain/answer/converter/AnswerConverter.java
@@ -1,9 +1,11 @@
 package root.git_turl.domain.answer.converter;
 
 import root.git_turl.domain.answer.dto.AnswerResDto;
+import root.git_turl.domain.answer.dto.VoiceFeedback;
 import root.git_turl.domain.answer.entity.Answer;
 import root.git_turl.domain.answer.enums.AnswerType;
 import root.git_turl.domain.question.entity.Question;
+import root.git_turl.domain.report.enums.GenerationStatus;
 
 public class AnswerConverter {
 
@@ -26,6 +28,16 @@ public class AnswerConverter {
                 .content(answer.getContent())
                 .feedback(answer.getFeedback())
                 .createdAt(answer.getCreatedAt().toLocalDate())
+                .build();
+    }
+
+    public static Answer toVoiceAnswer(
+            String voiceFileUrl
+    ) {
+        return Answer.builder()
+                .answerType(AnswerType.VOICE)
+                .voiceFile(voiceFileUrl)
+                .generationStatus(GenerationStatus.PROCESSING)
                 .build();
     }
 }

--- a/src/main/java/root/git_turl/domain/answer/converter/AnswerConverter.java
+++ b/src/main/java/root/git_turl/domain/answer/converter/AnswerConverter.java
@@ -4,6 +4,7 @@ import root.git_turl.domain.answer.dto.AnswerResDto;
 import root.git_turl.domain.answer.dto.VoiceFeedback;
 import root.git_turl.domain.answer.entity.Answer;
 import root.git_turl.domain.answer.enums.AnswerType;
+import root.git_turl.domain.answer.enums.Status;
 import root.git_turl.domain.question.entity.Question;
 import root.git_turl.domain.report.enums.GenerationStatus;
 
@@ -16,6 +17,7 @@ public class AnswerConverter {
         return Answer.builder()
                 .content(content)
                 .answerType(AnswerType.TEXT)
+                .generationStatus(GenerationStatus.DONE)
                 .question(question)
                 .build();
     }
@@ -38,6 +40,15 @@ public class AnswerConverter {
                 .answerType(AnswerType.VOICE)
                 .voiceFile(voiceFileUrl)
                 .generationStatus(GenerationStatus.PROCESSING)
+                .build();
+    }
+
+    public static Answer toVoiceAnswerPass(
+    ) {
+        return Answer.builder()
+                .answerType(AnswerType.VOICE)
+                .generationStatus(GenerationStatus.DONE)
+                .status(Status.PASSED)
                 .build();
     }
 }

--- a/src/main/java/root/git_turl/domain/answer/converter/AnswerConverter.java
+++ b/src/main/java/root/git_turl/domain/answer/converter/AnswerConverter.java
@@ -8,6 +8,8 @@ import root.git_turl.domain.answer.enums.Status;
 import root.git_turl.domain.question.entity.Question;
 import root.git_turl.domain.report.enums.GenerationStatus;
 
+import java.util.List;
+
 public class AnswerConverter {
 
     public static Answer toTextAnswer(
@@ -34,21 +36,41 @@ public class AnswerConverter {
     }
 
     public static Answer toVoiceAnswer(
-            String voiceFileUrl
+            String voiceFileUrl,
+            Question question
     ) {
         return Answer.builder()
                 .answerType(AnswerType.VOICE)
                 .voiceFile(voiceFileUrl)
                 .generationStatus(GenerationStatus.PROCESSING)
+                .question(question)
                 .build();
     }
 
     public static Answer toVoiceAnswerPass(
+            Question question
     ) {
         return Answer.builder()
                 .answerType(AnswerType.VOICE)
                 .generationStatus(GenerationStatus.DONE)
                 .status(Status.PASSED)
+                .question(question)
+                .build();
+    }
+
+    public static AnswerResDto.VoiceAnswer toVoiceAnswerDto(
+           Answer answer,
+           List<String> keywords
+    ) {
+        return AnswerResDto.VoiceAnswer.builder()
+                .answerId(answer.getId())
+                .content(answer.getContent())
+                .feedback(answer.getFeedback())
+                .createdAt(answer.getCreatedAt().toLocalDate())
+                .answerSummary(answer.getAnswerSummary())
+                .keywords(keywords)
+                .voiceFile(answer.getVoiceFile())
+                .status(answer.getStatus())
                 .build();
     }
 }

--- a/src/main/java/root/git_turl/domain/answer/dto/AnswerReqDto.java
+++ b/src/main/java/root/git_turl/domain/answer/dto/AnswerReqDto.java
@@ -1,8 +1,10 @@
 package root.git_turl.domain.answer.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
 
 public class AnswerReqDto {
 
@@ -12,4 +14,5 @@ public class AnswerReqDto {
         @Size(min = 1, max = 200)
         private String content;
     }
+
 }

--- a/src/main/java/root/git_turl/domain/answer/dto/AnswerResDto.java
+++ b/src/main/java/root/git_turl/domain/answer/dto/AnswerResDto.java
@@ -2,8 +2,10 @@ package root.git_turl.domain.answer.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import root.git_turl.domain.answer.enums.Status;
 
 import java.time.LocalDate;
+import java.util.List;
 
 public class AnswerResDto {
 
@@ -23,6 +25,10 @@ public class AnswerResDto {
         private String content;
         private String feedback;
         private LocalDate createdAt;
+        private String voiceFile;
+        private String answerSummary;
+        private List<String> keywords;
+        private Status status;
     }
 
     @Getter

--- a/src/main/java/root/git_turl/domain/answer/dto/AnswerResDto.java
+++ b/src/main/java/root/git_turl/domain/answer/dto/AnswerResDto.java
@@ -15,4 +15,19 @@ public class AnswerResDto {
         private String feedback;
         private LocalDate createdAt;
     }
+
+    @Getter
+    @Builder
+    public static class VoiceAnswer{
+        private Long answerId;
+        private String content;
+        private String feedback;
+        private LocalDate createdAt;
+    }
+
+    @Getter
+    @Builder
+    public static class TranscriptionResponse {
+        private String text;
+    }
 }

--- a/src/main/java/root/git_turl/domain/answer/dto/VoiceFeedback.java
+++ b/src/main/java/root/git_turl/domain/answer/dto/VoiceFeedback.java
@@ -1,0 +1,12 @@
+package root.git_turl.domain.answer.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class VoiceFeedback {
+    private String content;
+    private String answerSummary;
+    private List<String> keywords;
+}

--- a/src/main/java/root/git_turl/domain/answer/entity/Answer.java
+++ b/src/main/java/root/git_turl/domain/answer/entity/Answer.java
@@ -58,6 +58,7 @@ public class Answer extends BaseEntity {
 
     public void updateFeedback(String feedback) {
         this.feedback = feedback;
+        this.status = Status.ANSWERED;
     }
     public void updateVoiceAnswer(String content, String feedback, String answerSummary, String keyword) {
         this.content = content;

--- a/src/main/java/root/git_turl/domain/answer/entity/Answer.java
+++ b/src/main/java/root/git_turl/domain/answer/entity/Answer.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import root.git_turl.domain.answer.enums.AnswerType;
 import root.git_turl.domain.answer.enums.Status;
 import root.git_turl.domain.question.entity.Question;
+import root.git_turl.domain.report.enums.GenerationStatus;
 import root.git_turl.global.entity.BaseEntity;
 
 import java.util.List;
@@ -41,18 +42,33 @@ public class Answer extends BaseEntity {
     private String answerSummary;
 
     @Column(name = "keyword")
-    private List<String> keyword;
+    private String keyword;
 
     @Column(name = "status")
     @Enumerated(EnumType.STRING)
     private Status status;
 
+    @Column(name = "generation_status")
+    @Enumerated(EnumType.STRING)
+    private GenerationStatus generationStatus;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "question_id")
     private Question question;
 
-
     public void updateFeedback(String feedback) {
         this.feedback = feedback;
+    }
+    public void updateVoiceAnswer(String content, String feedback, String answerSummary, String keyword) {
+        this.content = content;
+        this.feedback = feedback;
+        this.answerSummary = answerSummary;
+        this.keyword = keyword;
+        this.status = Status.ANSWERED;
+        this.generationStatus = GenerationStatus.DONE;
+    }
+
+    public void updateGenerationStatus(GenerationStatus generationStatus) {
+        this.generationStatus = generationStatus;
     }
 }

--- a/src/main/java/root/git_turl/domain/answer/exception/code/AnswerErrorCode.java
+++ b/src/main/java/root/git_turl/domain/answer/exception/code/AnswerErrorCode.java
@@ -19,7 +19,11 @@ public enum AnswerErrorCode implements BaseErrorCode {
 
     FEEDBACK_ALREADY_EXISTS(HttpStatus.CONFLICT,
             "ANSWER409_1",
-            "해당 답변이 존재하지 않습니다.");
+            "해당 답변이 존재하지 않습니다."),
+
+    VOICE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR,
+            "VOICE500_1",
+            "영상 업로드에 실패했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/root/git_turl/domain/answer/exception/code/AnswerSuccessCode.java
+++ b/src/main/java/root/git_turl/domain/answer/exception/code/AnswerSuccessCode.java
@@ -23,7 +23,11 @@ public enum AnswerSuccessCode implements BaseSuccessCode {
 
     ANSWER_DELETE_OK(HttpStatus.OK,
             "ANSWER200_4",
-            "답변이 삭제되었습니다.");
+            "답변이 삭제되었습니다."),
+
+    ANSWER_PASS_OK(HttpStatus.OK,
+            "ANSWER200_5",
+            "답변이 패스 되었습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/root/git_turl/domain/answer/repository/AnswerRepository.java
+++ b/src/main/java/root/git_turl/domain/answer/repository/AnswerRepository.java
@@ -3,6 +3,7 @@ package root.git_turl.domain.answer.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import root.git_turl.domain.answer.entity.Answer;
+import root.git_turl.domain.answer.enums.AnswerType;
 import root.git_turl.domain.question.entity.Question;
 
 import java.util.Optional;
@@ -17,4 +18,6 @@ public interface AnswerRepository extends JpaRepository<Answer, Long> {
         WHERE a.id = :answerId
     """)
     Optional<Answer> findByIdWithQuestion(Long answerId);
+
+    boolean existsByQuestionAndAnswerType(Question question, AnswerType type);
 }

--- a/src/main/java/root/git_turl/domain/answer/service/AnswerService.java
+++ b/src/main/java/root/git_turl/domain/answer/service/AnswerService.java
@@ -12,6 +12,7 @@ import root.git_turl.domain.answer.dto.AnswerResDto;
 import root.git_turl.domain.answer.dto.Feedback;
 import root.git_turl.domain.answer.dto.VoiceFeedback;
 import root.git_turl.domain.answer.entity.Answer;
+import root.git_turl.domain.answer.enums.Status;
 import root.git_turl.domain.answer.exception.AnswerException;
 import root.git_turl.domain.answer.exception.code.AnswerErrorCode;
 import root.git_turl.domain.answer.repository.AnswerRepository;
@@ -101,6 +102,15 @@ public class AnswerService {
         answerRepository.save(answer);
 
         asyncAnswerService.saveAnswerVoice(question.getContent(), question.getTime(), voiceFileUrl, answer.getId());
+    }
+
+    @Transactional
+    public void savePass(Member currentMember, Long questionId) {
+        Question question = getQuestion(questionId);
+        validateAuthor(currentMember, question);
+
+        Answer answer = AnswerConverter.toVoiceAnswerPass();
+        answerRepository.save(answer);
     }
 
     private Question getQuestion(Long questionId) {

--- a/src/main/java/root/git_turl/domain/answer/service/AnswerService.java
+++ b/src/main/java/root/git_turl/domain/answer/service/AnswerService.java
@@ -1,24 +1,34 @@
 package root.git_turl.domain.answer.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 import root.git_turl.domain.answer.converter.AnswerConverter;
+import root.git_turl.domain.answer.dto.AnswerReqDto;
 import root.git_turl.domain.answer.dto.AnswerResDto;
 import root.git_turl.domain.answer.dto.Feedback;
+import root.git_turl.domain.answer.dto.VoiceFeedback;
 import root.git_turl.domain.answer.entity.Answer;
 import root.git_turl.domain.answer.exception.AnswerException;
 import root.git_turl.domain.answer.exception.code.AnswerErrorCode;
 import root.git_turl.domain.answer.repository.AnswerRepository;
+import root.git_turl.domain.member.code.MemberErrorCode;
 import root.git_turl.domain.member.entity.Member;
+import root.git_turl.domain.member.exception.MemberException;
 import root.git_turl.domain.question.entity.Question;
 import root.git_turl.domain.question.exception.QuestionException;
 import root.git_turl.domain.question.exception.code.QuestionErrorCode;
 import root.git_turl.domain.question.repository.QuestionRepository;
+import root.git_turl.domain.report.enums.GenerationStatus;
 import root.git_turl.global.apiPayload.exception.GeneralException;
+import root.git_turl.global.aws.AwsFileService;
 import root.git_turl.global.util.BuildPrompt;
 import root.git_turl.infrastructure.openai.GptService;
 
+import java.io.IOException;
 import java.util.List;
 
 @Service
@@ -29,11 +39,11 @@ public class AnswerService {
     private final AnswerRepository answerRepository;
     private final BuildPrompt buildPrompt;
     private final GptService gptService;
+    private final AsyncAnswerService asyncAnswerService;
+    private final AwsFileService awsFileService;
 
     public List<AnswerResDto.TextAnswer> getAnswerList(Member currentMember, Long questionId) {
-        Question question = questionRepository.findById(questionId)
-                .orElseThrow(() -> new QuestionException(QuestionErrorCode.NOT_FOUND));
-
+        Question question = getQuestion(questionId);
         validateAuthor(currentMember, question);
 
         return question.getAnswerList().stream().map(AnswerConverter::toTextAnswer).toList();
@@ -41,9 +51,7 @@ public class AnswerService {
 
     @Transactional
     public void saveAnswer(Member currentMember, Long questionId, String content) {
-        Question question = questionRepository.findById(questionId)
-                .orElseThrow(() -> new QuestionException(QuestionErrorCode.NOT_FOUND));
-
+        Question question = getQuestion(questionId);
         validateAuthor(currentMember, question);
 
         if (answerRepository.countByQuestion(question) == 3) {
@@ -56,9 +64,7 @@ public class AnswerService {
 
     @Transactional
     public void makeFeedback(Member currentMember, Long answerId) {
-        Answer answer = answerRepository.findByIdWithQuestion(answerId)
-                .orElseThrow(() -> new AnswerException(AnswerErrorCode.NOT_FOUND));
-
+        Answer answer = getAnswer(answerId);
         validateAuthor(currentMember, answer.getQuestion());
 
         if (answer.getFeedback() != null) {
@@ -72,12 +78,39 @@ public class AnswerService {
 
     @Transactional
     public void deleteAnswer(Member currentMember, Long answerId) {
-        Answer answer = answerRepository.findByIdWithQuestion(answerId)
-                .orElseThrow(() -> new AnswerException(AnswerErrorCode.NOT_FOUND));
-
+        Answer answer = getAnswer(answerId);
         validateAuthor(currentMember, answer.getQuestion());
 
         answerRepository.deleteById(answerId);
+    }
+
+    
+    @Transactional
+    public void saveAnswerVoice(Member currentMember, Long questionId, MultipartFile file) {
+        Question question = getQuestion(questionId);
+        validateAuthor(currentMember, question);
+
+        // S3에 음성 녹음본 저장
+        String voiceFileUrl;
+        try {
+            voiceFileUrl = awsFileService.uploadVoiceFile(file, currentMember.getId(), questionId);
+        } catch (IOException e) {
+            throw new MemberException(AnswerErrorCode.VOICE_UPLOAD_FAIL);
+        }
+        Answer answer = AnswerConverter.toVoiceAnswer(voiceFileUrl);
+        answerRepository.save(answer);
+
+        asyncAnswerService.saveAnswerVoice(question.getContent(), question.getTime(), voiceFileUrl, answer.getId());
+    }
+
+    private Question getQuestion(Long questionId) {
+        return questionRepository.findById(questionId)
+                .orElseThrow(() -> new QuestionException(QuestionErrorCode.NOT_FOUND));
+    }
+
+    private Answer getAnswer(Long answerId) {
+        return answerRepository.findByIdWithQuestion(answerId)
+                .orElseThrow(() -> new AnswerException(AnswerErrorCode.NOT_FOUND));
     }
 
     private static void validateAuthor(Member currentMember, Question question) {

--- a/src/main/java/root/git_turl/domain/answer/service/AnswerService.java
+++ b/src/main/java/root/git_turl/domain/answer/service/AnswerService.java
@@ -85,6 +85,10 @@ public class AnswerService {
         Answer answer = getAnswer(answerId);
         validateAuthor(currentMember, answer.getQuestion());
 
+        if (answer.getVoiceFile() != null) {
+            awsFileService.deleteFile(answer.getVoiceFile());
+        }
+
         answerRepository.deleteById(answerId);
     }
 

--- a/src/main/java/root/git_turl/domain/answer/service/AnswerService.java
+++ b/src/main/java/root/git_turl/domain/answer/service/AnswerService.java
@@ -1,6 +1,7 @@
 package root.git_turl.domain.answer.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,6 +13,7 @@ import root.git_turl.domain.answer.dto.AnswerResDto;
 import root.git_turl.domain.answer.dto.Feedback;
 import root.git_turl.domain.answer.dto.VoiceFeedback;
 import root.git_turl.domain.answer.entity.Answer;
+import root.git_turl.domain.answer.enums.AnswerType;
 import root.git_turl.domain.answer.enums.Status;
 import root.git_turl.domain.answer.exception.AnswerException;
 import root.git_turl.domain.answer.exception.code.AnswerErrorCode;
@@ -43,8 +45,9 @@ public class AnswerService {
     private final AsyncAnswerService asyncAnswerService;
     private final AwsFileService awsFileService;
 
+    @Transactional(readOnly = true)
     public List<AnswerResDto.TextAnswer> getAnswerList(Member currentMember, Long questionId) {
-        Question question = getQuestion(questionId);
+        Question question = getQuestionWithAnswers(questionId);
         validateAuthor(currentMember, question);
 
         return question.getAnswerList().stream().map(AnswerConverter::toTextAnswer).toList();
@@ -85,11 +88,41 @@ public class AnswerService {
         answerRepository.deleteById(answerId);
     }
 
+    @Transactional(readOnly = true)
+    public AnswerResDto.VoiceAnswer getVoiceAnswer(Member currentMember, Long questionId) {
+        Question question = getQuestionWithAnswers(questionId);
+        validateAuthor(currentMember, question);
+
+        Answer voiceAnswer = question.getAnswerList().stream()
+                .findFirst()
+                .orElseThrow(() -> new AnswerException(AnswerErrorCode.NOT_FOUND));
+
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        List<String> keywords = null;
+        try {
+            keywords = objectMapper.readValue(
+                    voiceAnswer.getKeyword(),
+                    new TypeReference<List<String>>() {}
+            );
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+
+        return AnswerConverter.toVoiceAnswerDto(voiceAnswer, keywords);
+    }
     
     @Transactional
     public void saveAnswerVoice(Member currentMember, Long questionId, MultipartFile file) {
         Question question = getQuestion(questionId);
         validateAuthor(currentMember, question);
+
+        boolean exists = answerRepository
+                .existsByQuestionAndAnswerType(question, AnswerType.VOICE);
+
+        if (exists) {
+            throw new AnswerException(AnswerErrorCode.ANSWER_OVER_RAGE);
+        }
 
         // S3에 음성 녹음본 저장
         String voiceFileUrl;
@@ -98,7 +131,7 @@ public class AnswerService {
         } catch (IOException e) {
             throw new MemberException(AnswerErrorCode.VOICE_UPLOAD_FAIL);
         }
-        Answer answer = AnswerConverter.toVoiceAnswer(voiceFileUrl);
+        Answer answer = AnswerConverter.toVoiceAnswer(voiceFileUrl, question);
         answerRepository.save(answer);
 
         asyncAnswerService.saveAnswerVoice(question.getContent(), question.getTime(), voiceFileUrl, answer.getId());
@@ -109,8 +142,13 @@ public class AnswerService {
         Question question = getQuestion(questionId);
         validateAuthor(currentMember, question);
 
-        Answer answer = AnswerConverter.toVoiceAnswerPass();
+        Answer answer = AnswerConverter.toVoiceAnswerPass(question);
         answerRepository.save(answer);
+    }
+
+    private Question getQuestionWithAnswers(Long questionId) {
+        return questionRepository.findQuestionWithAnswer(questionId)
+                .orElseThrow(() -> new QuestionException(QuestionErrorCode.NOT_FOUND));
     }
 
     private Question getQuestion(Long questionId) {

--- a/src/main/java/root/git_turl/domain/answer/service/AsyncAnswerService.java
+++ b/src/main/java/root/git_turl/domain/answer/service/AsyncAnswerService.java
@@ -1,0 +1,62 @@
+package root.git_turl.domain.answer.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import root.git_turl.domain.answer.dto.VoiceFeedback;
+import root.git_turl.domain.answer.entity.Answer;
+import root.git_turl.domain.answer.exception.AnswerException;
+import root.git_turl.domain.answer.exception.code.AnswerErrorCode;
+import root.git_turl.domain.answer.repository.AnswerRepository;
+import root.git_turl.domain.report.enums.GenerationStatus;
+import root.git_turl.global.util.BuildPrompt;
+import root.git_turl.infrastructure.openai.GptService;
+import root.git_turl.infrastructure.openai.WhisperService;
+
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class AsyncAnswerService {
+
+    private final AnswerRepository answerRepository;
+    private final BuildPrompt buildPrompt;
+    private final GptService gptService;
+    private final WhisperService whisperService;
+    private final ObjectMapper objectMapper;
+
+    @Async
+    @Transactional
+    public void saveAnswerVoice(
+            String questionContent, Integer questionTime,
+            String voiceFileUrl, Long answerId
+    ) {
+
+        Answer answer = answerRepository.findById(answerId)
+                .orElseThrow(() -> new AnswerException(AnswerErrorCode.NOT_FOUND));
+
+        // 음성 -> 텍스트 변환
+        String textAnswer = whisperService.transcribe(voiceFileUrl, answer);
+
+        // 답변 피드백 생성
+        String prompt = buildPrompt.buildSummaryAndFeedbackPrompt(textAnswer, questionContent, questionTime);
+        VoiceFeedback response = gptService.makeVoiceFeedback(prompt);
+
+        // 음성 답변, 피드백 저장
+        String keywords = null;
+        try {
+            keywords = objectMapper.writeValueAsString(response.getKeywords());
+        } catch (JsonProcessingException e) {
+            answer.updateGenerationStatus(GenerationStatus.FAIL);
+            throw new RuntimeException(e);
+        }
+        answer.updateVoiceAnswer(
+                textAnswer,
+                response.getContent(),
+                response.getAnswerSummary(),
+                keywords);
+    }
+}

--- a/src/main/java/root/git_turl/domain/member/code/MemberErrorCode.java
+++ b/src/main/java/root/git_turl/domain/member/code/MemberErrorCode.java
@@ -27,7 +27,7 @@ public enum MemberErrorCode implements BaseErrorCode {
 
     FILE_TYPE_ERROR(HttpStatus.BAD_REQUEST,
                 "FILE400",
-                    "이미지 파일만 업로드 가능합니다."),
+                    "올바르지 않은 파일 타입입니다."),
 
     IMAGE_UPLOAD_FAIL(HttpStatus.INTERNAL_SERVER_ERROR,
                 "FILE404",

--- a/src/main/java/root/git_turl/domain/question/controller/QuestionController.java
+++ b/src/main/java/root/git_turl/domain/question/controller/QuestionController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import root.git_turl.domain.answer.enums.AnswerType;
 import root.git_turl.domain.member.entity.Member;
 import root.git_turl.domain.question.dto.QuestionReqDto;
 import root.git_turl.domain.question.dto.QuestionResDto;
@@ -39,9 +40,10 @@ public class QuestionController implements QuestionControllerDocs{
     public ApiResponse<ReportResDto.Pagination<QuestionResDto.QuestionInfo>> getQuestions(
             @PathVariable Long reportId,
             @RequestParam(required = false) Integer pageSize,
-            @RequestParam(required = false) String cursor
-    ) {
-        ReportResDto.Pagination<QuestionResDto.QuestionInfo> response = questionService.getQuestionList(reportId, pageSize, cursor);
+            @RequestParam(required = false) String cursor,
+            @RequestParam AnswerType answerType
+            ) {
+        ReportResDto.Pagination<QuestionResDto.QuestionInfo> response = questionService.getQuestionList(reportId, pageSize, cursor, answerType);
         return ApiResponse.onSuccess(QuestionSuccessCode.QUESTION_LIST_GET_OK, response);
     }
 

--- a/src/main/java/root/git_turl/domain/question/controller/QuestionController.java
+++ b/src/main/java/root/git_turl/domain/question/controller/QuestionController.java
@@ -29,7 +29,7 @@ public class QuestionController implements QuestionControllerDocs{
     public ApiResponse<QuestionResDto.QuestionId> saveQuestion(
             @CurrentUser @Parameter(hidden = true) Member member,
             @PathVariable Long reportId,
-            @RequestBody @Valid QuestionReqDto.QuestionCount dto
+            @RequestBody @Valid QuestionReqDto.QuestionInfo dto
     ) {
         QuestionResDto.QuestionId response = questionService.saveQuestion(member, reportId, dto);
         return ApiResponse.onSuccess(QuestionSuccessCode.QUESTION_POST_OK, response);

--- a/src/main/java/root/git_turl/domain/question/controller/QuestionControllerDocs.java
+++ b/src/main/java/root/git_turl/domain/question/controller/QuestionControllerDocs.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import root.git_turl.domain.answer.enums.AnswerType;
 import root.git_turl.domain.member.entity.Member;
 import root.git_turl.domain.question.dto.QuestionReqDto;
 import root.git_turl.domain.question.dto.QuestionResDto;
@@ -35,7 +36,8 @@ public interface QuestionControllerDocs {
     public ApiResponse<ReportResDto.Pagination<QuestionResDto.QuestionInfo>> getQuestions(
             @PathVariable Long reportId,
             @RequestParam(required = false) Integer pageSize,
-            @RequestParam(required = false) String cursor
+            @RequestParam(required = false) String cursor,
+            @RequestParam AnswerType answerType
     );
 
     @Operation(

--- a/src/main/java/root/git_turl/domain/question/controller/QuestionControllerDocs.java
+++ b/src/main/java/root/git_turl/domain/question/controller/QuestionControllerDocs.java
@@ -25,7 +25,7 @@ public interface QuestionControllerDocs {
     public ApiResponse<QuestionResDto.QuestionId> saveQuestion(
             @CurrentUser @Parameter(hidden = true) Member member,
             @PathVariable Long reportId,
-            @RequestBody @Valid QuestionReqDto.QuestionCount dto
+            @RequestBody @Valid QuestionReqDto.QuestionInfo dto
     );
 
     @Operation(

--- a/src/main/java/root/git_turl/domain/question/converter/QuestionConverter.java
+++ b/src/main/java/root/git_turl/domain/question/converter/QuestionConverter.java
@@ -1,5 +1,6 @@
 package root.git_turl.domain.question.converter;
 
+import root.git_turl.domain.answer.enums.AnswerType;
 import root.git_turl.domain.member.entity.Member;
 import root.git_turl.domain.question.dto.QuestionResDto;
 import root.git_turl.domain.question.entity.Question;
@@ -11,12 +12,13 @@ public class QuestionConverter {
 
     public static Question toQuestion(
         Report report,
-        Member member
-
+        Member member,
+        AnswerType answerType
     ) {
         return Question.builder()
                 .report(report)
                 .member(member)
+                .answerType(answerType)
                 .build();
     }
 

--- a/src/main/java/root/git_turl/domain/question/dto/QuestionReqDto.java
+++ b/src/main/java/root/git_turl/domain/question/dto/QuestionReqDto.java
@@ -4,14 +4,18 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import root.git_turl.domain.answer.enums.AnswerType;
 
 public class QuestionReqDto {
 
     @Getter
-    public static class QuestionCount {
+    public static class QuestionInfo {
         @NotNull
         @Min(1)
         @Max(5)
         private Integer questionCount;
+
+        @NotNull
+        private AnswerType answerType;
     }
 }

--- a/src/main/java/root/git_turl/domain/question/entity/Question.java
+++ b/src/main/java/root/git_turl/domain/question/entity/Question.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import root.git_turl.domain.answer.entity.Answer;
+import root.git_turl.domain.answer.enums.AnswerType;
 import root.git_turl.domain.member.entity.Member;
 import root.git_turl.domain.report.entity.Report;
 import root.git_turl.domain.report.enums.GenerationStatus;
@@ -37,6 +38,10 @@ public class Question extends BaseEntity {
 
     @Column(name = "time")
     private Integer time;
+
+    @Column(name = "answer_type")
+    @Enumerated(EnumType.STRING)
+    private AnswerType answerType;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "report_id")

--- a/src/main/java/root/git_turl/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/root/git_turl/domain/question/repository/QuestionRepository.java
@@ -3,14 +3,25 @@ package root.git_turl.domain.question.repository;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import root.git_turl.domain.member.entity.Member;
 import root.git_turl.domain.question.entity.Question;
 import root.git_turl.domain.report.entity.Report;
 import root.git_turl.domain.report.enums.GenerationStatus;
+
+import java.util.Optional;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
     Slice<Question> findQuestionByReport_IdAndIdLessThanOrderByIdDesc(Long reportId, Long idCursor, PageRequest pageRequest);
     Slice<Question> findQuestionByReport_IdOrderByIdDesc(Long reportId, PageRequest pageRequest);
     long countByMemberAndStatus(Member member, GenerationStatus status);
     long countByReportAndStatus(Report report, GenerationStatus status);
+
+    @Query("""
+            SELECT q
+            FROM Question q
+            JOIN FETCH q.answerList
+            WHERE q.id = :questionId
+    """)
+    Optional<Question> findQuestionWithAnswer(Long questionId);
 }

--- a/src/main/java/root/git_turl/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/root/git_turl/domain/question/repository/QuestionRepository.java
@@ -13,8 +13,8 @@ import root.git_turl.domain.report.enums.GenerationStatus;
 import java.util.Optional;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
-    Slice<Question> findQuestionByReport_IdAndIdLessThanOrderByIdDesc(Long reportId, Long idCursor, PageRequest pageRequest);
-    Slice<Question> findQuestionByReport_IdOrderByIdDesc(Long reportId, PageRequest pageRequest);
+    Slice<Question> findQuestionByReport_IdAndAnswerTypeAndIdLessThanOrderByIdDesc(Long reportId, AnswerType answerType, Long idCursor, PageRequest pageRequest);
+    Slice<Question> findQuestionByReport_IdAndAnswerTypeOrderByIdDesc(Long reportId, AnswerType answerType, PageRequest pageRequest);
     long countByMemberAndStatus(Member member, GenerationStatus status);
 
     @Query("""

--- a/src/main/java/root/git_turl/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/root/git_turl/domain/question/repository/QuestionRepository.java
@@ -5,10 +5,12 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import root.git_turl.domain.member.entity.Member;
 import root.git_turl.domain.question.entity.Question;
+import root.git_turl.domain.report.entity.Report;
 import root.git_turl.domain.report.enums.GenerationStatus;
 
 public interface QuestionRepository extends JpaRepository<Question, Long> {
     Slice<Question> findQuestionByReport_IdAndIdLessThanOrderByIdDesc(Long reportId, Long idCursor, PageRequest pageRequest);
     Slice<Question> findQuestionByReport_IdOrderByIdDesc(Long reportId, PageRequest pageRequest);
     long countByMemberAndStatus(Member member, GenerationStatus status);
+    long countByReportAndStatus(Report report, GenerationStatus status);
 }

--- a/src/main/java/root/git_turl/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/root/git_turl/domain/question/repository/QuestionRepository.java
@@ -4,6 +4,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import root.git_turl.domain.answer.enums.AnswerType;
 import root.git_turl.domain.member.entity.Member;
 import root.git_turl.domain.question.entity.Question;
 import root.git_turl.domain.report.entity.Report;
@@ -15,7 +16,15 @@ public interface QuestionRepository extends JpaRepository<Question, Long> {
     Slice<Question> findQuestionByReport_IdAndIdLessThanOrderByIdDesc(Long reportId, Long idCursor, PageRequest pageRequest);
     Slice<Question> findQuestionByReport_IdOrderByIdDesc(Long reportId, PageRequest pageRequest);
     long countByMemberAndStatus(Member member, GenerationStatus status);
-    long countByReportAndStatus(Report report, GenerationStatus status);
+
+    @Query("""
+            SELECT COUNT(DISTINCT q)
+            FROM Question q
+            WHERE q.report = :report
+            AND q.status = :status
+            AND q.answerType = :answerType
+    """)
+    long countByReportAndStatus(Report report, GenerationStatus status, AnswerType answerType);
 
     @Query("""
             SELECT q

--- a/src/main/java/root/git_turl/domain/question/service/QuestionService.java
+++ b/src/main/java/root/git_turl/domain/question/service/QuestionService.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import root.git_turl.domain.answer.enums.AnswerType;
 import root.git_turl.domain.member.code.MemberErrorCode;
 import root.git_turl.domain.member.entity.Member;
 import root.git_turl.domain.member.exception.MemberException;
@@ -56,7 +57,8 @@ public class QuestionService {
     public ReportResDto.Pagination<QuestionResDto.QuestionInfo> getQuestionList(
             Long reportId,
             Integer pageSize,
-            String cursor
+            String cursor,
+            AnswerType answerType
     ) {
         if (pageSize == null) pageSize = 10;
         if (cursor == null) cursor = "-1";
@@ -69,9 +71,9 @@ public class QuestionService {
 
         if (!cursor.equals("-1")) {
             idCursor = Long.parseLong(cursor);
-            questionList = questionRepository.findQuestionByReport_IdAndIdLessThanOrderByIdDesc(reportId, idCursor, pageRequest);
+            questionList = questionRepository.findQuestionByReport_IdAndAnswerTypeAndIdLessThanOrderByIdDesc(reportId, answerType, idCursor, pageRequest);
         } else {
-            questionList = questionRepository.findQuestionByReport_IdOrderByIdDesc(reportId, pageRequest);
+            questionList = questionRepository.findQuestionByReport_IdAndAnswerTypeOrderByIdDesc(reportId, answerType,pageRequest);
         }
 
         nextCursor = questionList.getContent().getLast().getId().toString();

--- a/src/main/java/root/git_turl/domain/question/service/QuestionService.java
+++ b/src/main/java/root/git_turl/domain/question/service/QuestionService.java
@@ -37,7 +37,7 @@ public class QuestionService {
     private final AsyncQuestionService asyncQuestionService;
 
     @Transactional
-    public QuestionResDto.QuestionId saveQuestion(Member currentMember, Long reportId, QuestionReqDto.QuestionCount dto) {
+    public QuestionResDto.QuestionId saveQuestion(Member currentMember, Long reportId, QuestionReqDto.QuestionInfo dto) {
         Report report = reportRepository.findById(reportId)
                 .orElseThrow(() -> new ReportException(ReportErrorCode.REPORT_NOT_FOUND));
         Member member = memberRepository.findById(currentMember.getId())
@@ -45,7 +45,7 @@ public class QuestionService {
 
         List<Question> questions = new ArrayList<>();
         for (int i=0; i<dto.getQuestionCount(); i++) {
-            Question question = QuestionConverter.toQuestion(report, member);
+            Question question = QuestionConverter.toQuestion(report, member, dto.getAnswerType());
             questions.add(question);
         }
         questionRepository.saveAll(questions);

--- a/src/main/java/root/git_turl/domain/report/controller/ReportController.java
+++ b/src/main/java/root/git_turl/domain/report/controller/ReportController.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import root.git_turl.domain.answer.enums.AnswerType;
 import root.git_turl.domain.member.entity.Member;
 import root.git_turl.domain.report.code.ReportSuccessCode;
 import root.git_turl.domain.report.dto.ReportReqDto;
@@ -69,9 +70,10 @@ public class ReportController implements ReportControllerDocs{
             @RequestParam(required = false) String cursor,
             @RequestParam(required = false) LocalDate startDate,
             @RequestParam(required = false) LocalDate endDate,
-            @RequestParam(required = false) Status status
+            @RequestParam(required = false) Status status,
+            @RequestParam AnswerType answerType
     ) {
-        ReportResDto.Pagination<ReportResDto.ReportPreview> response = reportService.getReportList(member, pageSize, cursor, startDate, endDate, status);
+        ReportResDto.Pagination<ReportResDto.ReportPreview> response = reportService.getReportList(member, pageSize, cursor, startDate, endDate, status, answerType);
         if (response == null) {
             return ApiResponse.onSuccess(ReportSuccessCode.NO_REPORT_FOUND, null);
         }

--- a/src/main/java/root/git_turl/domain/report/controller/ReportController.java
+++ b/src/main/java/root/git_turl/domain/report/controller/ReportController.java
@@ -70,7 +70,7 @@ public class ReportController implements ReportControllerDocs{
             @RequestParam(required = false) LocalDate startDate,
             @RequestParam(required = false) LocalDate endDate,
             @RequestParam(required = false) Status status
-            ) {
+    ) {
         ReportResDto.Pagination<ReportResDto.ReportPreview> response = reportService.getReportList(member, pageSize, cursor, startDate, endDate, status);
         if (response == null) {
             return ApiResponse.onSuccess(ReportSuccessCode.NO_REPORT_FOUND, null);

--- a/src/main/java/root/git_turl/domain/report/controller/ReportControllerDocs.java
+++ b/src/main/java/root/git_turl/domain/report/controller/ReportControllerDocs.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import root.git_turl.domain.answer.enums.AnswerType;
 import root.git_turl.domain.member.entity.Member;
 import root.git_turl.domain.report.dto.ReportReqDto;
 import root.git_turl.domain.report.dto.ReportResDto;
@@ -65,7 +66,8 @@ public interface ReportControllerDocs {
             @RequestParam(required = false) String cursor,
             @RequestParam(required = false) LocalDate startDate,
             @RequestParam(required = false) LocalDate endDate,
-            @RequestParam(required = false) Status status
+            @RequestParam(required = false) Status status,
+            @RequestParam(required = false) AnswerType answerType
     );
 
     @Operation(

--- a/src/main/java/root/git_turl/domain/report/converter/ReportConverter.java
+++ b/src/main/java/root/git_turl/domain/report/converter/ReportConverter.java
@@ -81,13 +81,15 @@ public class ReportConverter {
     }
 
     public static ReportResDto.ReportPreview toReportPreview(
-            Report report
+            Report report,
+            long count
     ) {
         return ReportResDto.ReportPreview.builder()
                 .reportId(report.getId())
-                .reopName(report.getRepoName())
+                .repoName(report.getRepoName())
                 .description(report.getDescription())
-                .createdAt(report.getCreatedAt())
+                .createdAt(report.getCreatedAt().toLocalDate())
+                .questionCount(count)
                 .build();
     }
 
@@ -96,7 +98,7 @@ public class ReportConverter {
     ) {
         return ReportResDto.NewTitle.builder()
                 .title(report.getTitle())
-                .updatedAt(report.getUpdatedAt())
+                .updatedAt(report.getUpdatedAt().toLocalDate())
                 .build();
     }
 }

--- a/src/main/java/root/git_turl/domain/report/dto/ReportResDto.java
+++ b/src/main/java/root/git_turl/domain/report/dto/ReportResDto.java
@@ -1,11 +1,11 @@
 package root.git_turl.domain.report.dto;
 
-import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 import lombok.Getter;
 import root.git_turl.domain.report.dto.reportDetail.ReportWrapper;
 import root.git_turl.domain.report.enums.Status;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -57,15 +57,16 @@ public class ReportResDto {
     @Builder
     public static class ReportPreview {
         private Long reportId;
-        private String reopName;
+        private String repoName;
         private String description;
-        private LocalDateTime createdAt;
+        private LocalDate createdAt;
+        private Long questionCount;
     }
 
     @Getter
     @Builder
     public static class NewTitle {
         private String title;
-        private LocalDateTime updatedAt;
+        private LocalDate updatedAt;
     }
 }

--- a/src/main/java/root/git_turl/domain/report/service/ReportService.java
+++ b/src/main/java/root/git_turl/domain/report/service/ReportService.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import root.git_turl.domain.member.entity.Member;
+import root.git_turl.domain.question.repository.QuestionRepository;
 import root.git_turl.domain.report.code.ReportErrorCode;
 import root.git_turl.domain.report.converter.ReportConverter;
 import root.git_turl.domain.report.dto.GithubRepoResponse;
@@ -31,6 +32,7 @@ public class ReportService {
     private final GithubClient githubClient;
     private final ReportAsyncService reportAsyncService;
     private final ReportRepository reportRepository;
+    private final QuestionRepository questionRepository;
 
     @Transactional(readOnly = true)
     public List<ReportResDto.RepoInfo> getRepoList(String token) {
@@ -124,8 +126,11 @@ public class ReportService {
         nextCursor = reportList.getContent().getLast().getId().toString();
         List<ReportResDto.ReportPreview> reportPreviewList =
                 reportList.stream()
-                        .map(ReportConverter::toReportPreview)
-                        .toList();
+                        .map(report ->
+                                ReportConverter.toReportPreview(
+                                        report,
+                                        questionRepository.countByReportAndStatus(report, GenerationStatus.DONE))
+                        ).toList();
 
         return Pagination.toPagination(reportPreviewList, reportList.hasNext(), nextCursor, reportList.getContent().size());
     }

--- a/src/main/java/root/git_turl/domain/report/service/ReportService.java
+++ b/src/main/java/root/git_turl/domain/report/service/ReportService.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import root.git_turl.domain.answer.enums.AnswerType;
 import root.git_turl.domain.member.entity.Member;
 import root.git_turl.domain.question.repository.QuestionRepository;
 import root.git_turl.domain.report.code.ReportErrorCode;
@@ -74,13 +75,15 @@ public class ReportService {
         return ReportConverter.toNewStatus(report.getStatus());
     }
 
+    @Transactional(readOnly = true)
     public ReportResDto.Pagination<ReportResDto.ReportPreview> getReportList(
             Member currentMember,
             Integer pageSize,
             String cursor,
             LocalDate startDate,
             LocalDate endDate,
-            Status status
+            Status status,
+            AnswerType answerType
     ) {
         if (pageSize == null) pageSize = 10;
         if (cursor == null) cursor = "-1";
@@ -129,7 +132,7 @@ public class ReportService {
                         .map(report ->
                                 ReportConverter.toReportPreview(
                                         report,
-                                        questionRepository.countByReportAndStatus(report, GenerationStatus.DONE))
+                                        questionRepository.countByReportAndStatus(report, GenerationStatus.DONE, answerType))
                         ).toList();
 
         return Pagination.toPagination(reportPreviewList, reportList.hasNext(), nextCursor, reportList.getContent().size());

--- a/src/main/java/root/git_turl/global/aws/AwsFileService.java
+++ b/src/main/java/root/git_turl/global/aws/AwsFileService.java
@@ -11,6 +11,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
+import java.util.Set;
 import java.util.UUID;
 
 @Service
@@ -49,7 +50,53 @@ public class AwsFileService {
         return getPublicUrl(fileName);
     }
 
+    public String uploadVoiceFile(MultipartFile file, Long memberId, Long questionId) throws IOException {
+
+        if (file.getContentType() == null ||
+                !file.getContentType().startsWith("audio/")) {
+            throw new MemberException(MemberErrorCode.FILE_TYPE_ERROR);
+        }
+
+        String originalName = file.getOriginalFilename();
+        System.out.println(originalName);
+        System.out.println(file.getContentType());
+        String ext = originalName.substring(originalName.lastIndexOf("."));
+
+        String fileName = "voiceFile/" + memberId + "/questions/" + questionId + UUID.randomUUID() + ext;
+
+        String contentType = normalizeContentType(file.getContentType(), ext);
+
+        byte[] bytes = file.getBytes();
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(fileName)
+                .contentType(contentType)
+                .contentLength((long) bytes.length)
+                .contentDisposition("inline")
+                .build();
+
+        s3Client.putObject(
+                putObjectRequest,
+                RequestBody.fromBytes(bytes)
+        );
+
+        return getPublicUrl(fileName);
+    }
+
     private String getPublicUrl(String key) {
         return "https://" + bucket + ".s3.amazonaws.com/" + key;
+    }
+
+    private String normalizeContentType(String contentType, String ext) {
+
+        if (contentType == null) return "audio/mp4";
+
+        return switch (ext.toLowerCase()) {
+            case ".mp3" -> "audio/mpeg";
+            case ".wav" -> "audio/wav";
+            case ".m4a" -> "audio/mp4";
+            case ".webm" -> "audio/webm";
+            default -> contentType.replace("x-m4a", "mp4");
+        };
     }
 }

--- a/src/main/java/root/git_turl/global/aws/AwsFileService.java
+++ b/src/main/java/root/git_turl/global/aws/AwsFileService.java
@@ -8,6 +8,7 @@ import root.git_turl.domain.member.code.MemberErrorCode;
 import root.git_turl.domain.member.exception.MemberException;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 import java.io.IOException;
@@ -58,8 +59,7 @@ public class AwsFileService {
         }
 
         String originalName = file.getOriginalFilename();
-        System.out.println(originalName);
-        System.out.println(file.getContentType());
+
         String ext = originalName.substring(originalName.lastIndexOf("."));
 
         String fileName = "voiceFile/" + memberId + "/questions/" + questionId + UUID.randomUUID() + ext;
@@ -83,9 +83,25 @@ public class AwsFileService {
         return getPublicUrl(fileName);
     }
 
+    public void deleteFile(String url) {
+        String key = getKey(url);
+
+        DeleteObjectRequest request = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        s3Client.deleteObject(request);
+    }
+
     private String getPublicUrl(String key) {
         return "https://" + bucket + ".s3.amazonaws.com/" + key;
     }
+
+    private String getKey(String url) {
+        return url.substring(url.indexOf(".com/") + 5);
+    }
+
 
     private String normalizeContentType(String contentType, String ext) {
 

--- a/src/main/java/root/git_turl/global/util/BuildPrompt.java
+++ b/src/main/java/root/git_turl/global/util/BuildPrompt.java
@@ -169,4 +169,34 @@ public class BuildPrompt {
                         "{\"content\": \"...\"}\n");
         return sb.toString();
     }
+
+    public String buildSummaryAndFeedbackPrompt(String content, String questionContent, Integer questionTime) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("개발자 면접 질문에 대한 사용자의 답변을 평가하세요. \n");
+        sb.append("질문: ")
+                .append(questionContent)
+                .append("\n");
+        sb.append("적당한 응답 시간: ")
+                .append(questionTime)
+                .append("\n");
+        sb.append("사용자 응답: ")
+                .append(content)
+                .append("\n");
+        sb.append("평가 항목은 다음과 같습니다. 근거성\t답변 내용이 질문 의도와 레포 내용에 명확히 근거함. “왜 틀렸는지/왜 부족한지”가 분명함.\n" +
+                "논리성\t주장-이유-예시-결론 흐름이 자연스럽고 설득력 있음.\n" +
+                "구체성\t“어떤 부분을 어떻게 고쳐야 하는지”까지 명확히 제시함.\n" +
+                "개선 가능성\t바로 다음 답변이나 다음 작업에 적용 가능함. \n" +
+                "반드시 JSON 형식으로만 응답한다. 다른 어떤 텍스트도 포함하지 않는다.\n" +
+                "마크다운 금지, 설명 금지, 코드블록 금지.\n" +
+                "content 필드는 반드시 하나의 문자열로 작성하며 줄바꿈(\\n) 없이 255자 이내로 작성한다.\n" +
+                "문장은 자연스럽게 작성하되 하나의 문단으로만 구성한다.\n" +
+                "content에는 피드백 내용을, answerSummary는 답변 내용을 1~2줄로 요약하고, keywords에는 해당 답변에 대한 키워드를 List<String>형식으로 반환한다.\n" +
+                "반환 형식:\n" +
+                "{\n" +
+                "  \"content\": \"...\",\n" +
+                "  \"answerSummary\": \"...\",\n" +
+                "  \"keywords\": [\"...\"]\n" +
+                "}");
+        return sb.toString();
+    }
 }

--- a/src/main/java/root/git_turl/infrastructure/openai/GptService.java
+++ b/src/main/java/root/git_turl/infrastructure/openai/GptService.java
@@ -4,13 +4,15 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
+import root.git_turl.domain.answer.dto.AnswerResDto;
 import root.git_turl.domain.answer.dto.Feedback;
+import root.git_turl.domain.answer.dto.VoiceFeedback;
 import root.git_turl.domain.question.dto.QuestionContent;
 import root.git_turl.domain.report.dto.gpt.GptMessage;
 import root.git_turl.domain.report.dto.gpt.GptRequest;
@@ -25,6 +27,8 @@ public class GptService {
     private final RestTemplate restTemplate;
     private final ObjectMapper objectMapper;
 
+    private final String OPENAI_API = "https://api.openai.com/v1";
+
     @Value("${openai.api-key}")
     public String openAiApiKey;
 
@@ -38,6 +42,10 @@ public class GptService {
 
     public Feedback makeFeedback(String prompt) {
         return requestGpt(prompt, Feedback.class);
+    }
+
+    public VoiceFeedback makeVoiceFeedback(String prompt) {
+        return requestGpt(prompt, VoiceFeedback.class);
     }
 
     private <T> T requestGpt(String prompt, Class<T> classType) {
@@ -57,7 +65,7 @@ public class GptService {
 
         ResponseEntity<GptResponse> response =
                 restTemplate.postForEntity(
-                        "https://api.openai.com/v1/chat/completions",
+                        OPENAI_API + "/chat/completions",
                         entity,
                         GptResponse.class
                 );

--- a/src/main/java/root/git_turl/infrastructure/openai/MultipartInputStreamFileResource.java
+++ b/src/main/java/root/git_turl/infrastructure/openai/MultipartInputStreamFileResource.java
@@ -1,0 +1,28 @@
+package root.git_turl.infrastructure.openai;
+
+import org.springframework.core.io.InputStreamResource;
+
+import java.io.InputStream;
+
+public class MultipartInputStreamFileResource extends InputStreamResource {
+
+    private final String filename;
+
+    public MultipartInputStreamFileResource(
+            InputStream inputStream,
+            String filename
+    ) {
+        super(inputStream);
+        this.filename = filename;
+    }
+
+    @Override
+    public String getFilename() {
+        return this.filename;
+    }
+
+    @Override
+    public long contentLength() {
+        return -1;
+    }
+}

--- a/src/main/java/root/git_turl/infrastructure/openai/WhisperService.java
+++ b/src/main/java/root/git_turl/infrastructure/openai/WhisperService.java
@@ -1,0 +1,70 @@
+package root.git_turl.infrastructure.openai;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import root.git_turl.domain.answer.dto.AnswerResDto;
+import root.git_turl.domain.answer.entity.Answer;
+import root.git_turl.domain.report.enums.GenerationStatus;
+
+import java.io.InputStream;
+import java.net.URL;
+
+@Service
+@RequiredArgsConstructor
+public class WhisperService {
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    private final String OPENAI_API = "https://api.openai.com/v1";
+
+    @Value("${openai.api-key}")
+    public String openAiApiKey;
+
+    public String transcribe(String url, Answer answer) {
+        try {
+
+            InputStream inputStream = new URL(url).openStream();
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.MULTIPART_FORM_DATA);
+            headers.setBearerAuth(openAiApiKey);
+
+            MultiValueMap<String, Object> body = new LinkedMultiValueMap<>();
+
+            body.add("model", "whisper-1");
+
+            body.add("file", new MultipartInputStreamFileResource(
+                    inputStream,
+                    "audio.webm"
+            ));
+
+            HttpEntity<MultiValueMap<String, Object>> requestEntity =
+                    new HttpEntity<>(body, headers);
+
+            ResponseEntity<AnswerResDto.TranscriptionResponse> response =
+                    restTemplate.exchange(
+                            OPENAI_API + "/audio/transcriptions",
+                            HttpMethod.POST,
+                            requestEntity,
+                            AnswerResDto.TranscriptionResponse.class
+                    );
+
+            if (response.getBody() == null) {
+                answer.updateGenerationStatus(GenerationStatus.FAIL);
+                throw new RuntimeException("STT 응답이 비어있음");
+            }
+
+            return response.getBody().getText();
+
+        } catch (Exception e) {
+            answer.updateGenerationStatus(GenerationStatus.FAIL);
+            throw new RuntimeException("음성 파일 처리 실패", e);
+        }
+    }
+}

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -31,6 +31,11 @@ spring:
               - user:email
             redirect-uri: "{baseUrl}/login/oauth2/code/{registrationId}"
 
+  servlet:
+    multipart:
+      max-file-size: 20MB
+      max-request-size: 20MB
+
 jwt:
   token:
     secretKey: ${JWT_SECRET_KEY}


### PR DESCRIPTION
## 💡 관련 이슈
- close #60

<br>

## 📝 작업 내용
**음성 답변 관련**
<img width="1080" height="131" alt="image" src="https://github.com/user-attachments/assets/5adfd02e-2c08-4f56-bf5d-8a49107c1e7f" />

- 음성 답변 저장 api
녹음본 S3에 저장 후 정답 레코드 생성 (답변 타입, 처리 상태, 녹음본 url, 질문 객체만 저장) 후 응답처리
비동기로 음성 -> 텍스트 추출, 피드백, 한줄요약, 키워드 생성 후 추후 레코드 업데이트
 
- 음성 답변 패스 api
상태를 PASS로 설정한 빈 Answer 레코드 생성

- 음성 답변 & 피드백 조회 api
텍스트 답변과 달리 1건 조회 (음성 답변은 1개만 가능해서)

**리팩토링**
- 리포트 목록 조회, dto 수정
리포트 목록 조회 시 관련 질문 개수도 반환하도록 추가

- 답변 삭제 시 S3 파일도 삭제
AwsFileService에 deleteFile 구현 + 답변 삭제 시 음성 파일도 삭제하도록 설정

-   요약본 목록 조회 시 질문 타입 필터링
면접  >  면접 질문 내역에서 요약본 별 질문 개수를 텍스트 / 음성면접 별로 다르게 카운트

- 질문 목록 조회 시 질문 타입 필터링
특정 레포의 질문 목록 조회 시 텍스트 / 음성면접 별도로 조회 가능하게 수정


<br>

## 🛠️ 기타
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
