### PR TITLE
[Feat] 커뮤니티 API 스터디/프로젝트 게시판 수정

### DIFF
--- a/src/main/java/root/git_turl/domain/board/code/BoardErrorCode.java
+++ b/src/main/java/root/git_turl/domain/board/code/BoardErrorCode.java
@@ -43,7 +43,13 @@ public enum BoardErrorCode implements BaseErrorCode {
             HttpStatus.BAD_REQUEST,
             "BOARD400_4",
             "수정할 게시글 정보가 없습니다"
-    );;
+    ),
+
+    INVALID_BOARD_TYPE(
+            HttpStatus.BAD_REQUEST,
+            "BOARD400_5",
+            "잘못된 게시판 타입입니다"
+    ),;
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/root/git_turl/domain/board/controller/BoardControllerDocs.java
+++ b/src/main/java/root/git_turl/domain/board/controller/BoardControllerDocs.java
@@ -3,14 +3,13 @@ package root.git_turl.domain.board.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.multipart.MultipartFile;
 import root.git_turl.domain.board.dto.BoardReqDto;
 import root.git_turl.domain.board.dto.BoardResDto;
-import root.git_turl.domain.board.enums.BoardType;
+import root.git_turl.domain.board.enums.*;
 import root.git_turl.domain.member.entity.Member;
 import root.git_turl.global.annotation.CurrentUser;
 import root.git_turl.global.apiPayload.ApiResponse;
@@ -52,8 +51,27 @@ public interface BoardControllerDocs {
             description = "게시글 목록을 조회합니다."
     )
     ApiResponse<BoardResDto.BoardPreviewListDto> getBoardList(
-            @RequestParam(defaultValue = "0") Integer page,
-            @RequestParam(required = false) BoardType boardType
+
+            @RequestParam(defaultValue = "0")
+            Integer page,
+
+            @RequestParam(required = false)
+            BoardType boardType,
+
+            @RequestParam(required = false)
+            StudyTag studyTag,
+
+            @RequestParam(required = false)
+            ProjectStatus projectStatus,
+
+            @RequestParam(required = false)
+            TechField techField,
+
+            @RequestParam(required = false)
+            PlatformType platformType,
+
+            @RequestParam(defaultValue = "LATEST")
+            BoardSortType sort
     );
 
     @Operation(

--- a/src/main/java/root/git_turl/domain/board/controller/BoardRestController.java
+++ b/src/main/java/root/git_turl/domain/board/controller/BoardRestController.java
@@ -9,11 +9,10 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import root.git_turl.domain.board.code.BoardSuccessCode;
-import root.git_turl.domain.board.enums.BoardType;
+import root.git_turl.domain.board.enums.*;
 import root.git_turl.domain.board.service.BoardCommandService;
 import root.git_turl.domain.board.service.BoardQueryService;
 import root.git_turl.domain.member.entity.Member;
-import root.git_turl.domain.member.repository.MemberRepository;
 import root.git_turl.global.annotation.CurrentUser;
 import root.git_turl.global.annotation.SwaggerBody;
 import root.git_turl.global.apiPayload.ApiResponse;
@@ -94,11 +93,24 @@ public class BoardRestController implements BoardControllerDocs {
     @GetMapping
     public ApiResponse<BoardResDto.BoardPreviewListDto> getBoardList(
             @RequestParam(defaultValue = "0") Integer page,
-            @RequestParam(required = false) BoardType boardType
+            @RequestParam(required = false) BoardType boardType,
+            @RequestParam(required = false) StudyTag studyTag,
+            @RequestParam(required = false) ProjectStatus projectStatus,
+            @RequestParam(required = false) TechField techField,
+            @RequestParam(required = false) PlatformType platformType,
+            @RequestParam(defaultValue = "LATEST") BoardSortType sort
     ) {
         return ApiResponse.onSuccess(
                 BoardSuccessCode.BOARD_LIST_FOUND,
-                boardQueryService.getBoardList(page, boardType)
+                boardQueryService.getBoardList(
+                        page,
+                        boardType,
+                        studyTag,
+                        projectStatus,
+                        techField,
+                        platformType,
+                        sort
+                )
         );
     }
 

--- a/src/main/java/root/git_turl/domain/board/converter/BoardConverter.java
+++ b/src/main/java/root/git_turl/domain/board/converter/BoardConverter.java
@@ -1,12 +1,12 @@
 package root.git_turl.domain.board.converter;
 
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Component;
 import root.git_turl.domain.board.dto.BoardReqDto;
 import root.git_turl.domain.board.dto.BoardResDto;
 import root.git_turl.domain.board.entity.Board;
 import root.git_turl.domain.board.repository.BoardLikeRepository;
 import root.git_turl.domain.member.entity.Member;
-import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -14,11 +14,24 @@ import java.util.List;
 @Component
 public class BoardConverter {
 
-    public Board toBoard(BoardReqDto.CreateBoardReqDto request, Member member, String imageUrl) {
+    public Board toBoard(
+            BoardReqDto.CreateBoardReqDto request,
+            Member member,
+            String imageUrl
+    ) {
         return Board.builder()
                 .title(request.getTitle())
                 .content(request.getContent())
                 .boardType(request.getBoardType())
+
+                // ===== 스터디 =====
+                .studyTag(request.getStudyTag())
+
+                // ===== 프로젝트 =====
+                .projectStatus(request.getProjectStatus())
+                .techFields(request.getTechFields())
+                .platformTypes(request.getPlatformTypes())
+
                 .imageUrl(imageUrl)
                 .member(member)
                 .build();
@@ -35,6 +48,15 @@ public class BoardConverter {
                 .content(board.getContent())
                 .imageUrl(board.getImageUrl())
                 .boardType(board.getBoardType())
+
+                // ===== 스터디 =====
+                .studyTag(board.getStudyTag())
+
+                // ===== 프로젝트 =====
+                .projectStatus(board.getProjectStatus())
+                .techFields(board.getTechFields())
+                .platformTypes(board.getPlatformTypes())
+
                 .authorName(board.getMember().getNickname())
                 .views(board.getViews())
                 .likeCount(likeCount)
@@ -74,6 +96,15 @@ public class BoardConverter {
                 .content(board.getContent())
                 .imageUrl(board.getImageUrl())
                 .boardType(board.getBoardType())
+
+                // ===== 스터디 =====
+                .studyTag(board.getStudyTag())
+
+                // ===== 프로젝트 =====
+                .projectStatus(board.getProjectStatus())
+                .techFields(board.getTechFields())
+                .platformTypes(board.getPlatformTypes())
+
                 .writerName(board.getMember().getNickname())
                 .likeCount(likeCount)
                 .createdAt(board.getCreatedAt())

--- a/src/main/java/root/git_turl/domain/board/dto/BoardReqDto.java
+++ b/src/main/java/root/git_turl/domain/board/dto/BoardReqDto.java
@@ -4,8 +4,9 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import lombok.Getter;
-import org.springframework.web.multipart.MultipartFile;
-import root.git_turl.domain.board.enums.BoardType;
+import root.git_turl.domain.board.enums.*;
+
+import java.util.List;
 
 public class BoardReqDto {
 
@@ -21,6 +22,16 @@ public class BoardReqDto {
         @NotNull
         private BoardType boardType;
 
+        // ===== 스터디 게시판 =====
+        private StudyTag studyTag;
+
+        // ===== 프로젝트 게시판 =====
+        private ProjectStatus projectStatus;
+
+        private List<TechField> techFields;
+
+        private List<PlatformType> platformTypes;
+
         //private MultipartFile boardImage;
     }
 
@@ -32,6 +43,16 @@ public class BoardReqDto {
         private String content;
 
         private BoardType boardType;
+
+        // ===== 스터디 게시판 =====
+        private StudyTag studyTag;
+
+        // ===== 프로젝트 게시판 =====
+        private ProjectStatus projectStatus;
+
+        private List<TechField> techFields;
+
+        private List<PlatformType> platformTypes;
 
         //private MultipartFile boardImage;
     }

--- a/src/main/java/root/git_turl/domain/board/dto/BoardResDto.java
+++ b/src/main/java/root/git_turl/domain/board/dto/BoardResDto.java
@@ -2,7 +2,7 @@ package root.git_turl.domain.board.dto;
 
 import lombok.Builder;
 import lombok.Getter;
-import root.git_turl.domain.board.enums.BoardType;
+import root.git_turl.domain.board.enums.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -12,60 +12,110 @@ public class BoardResDto {
     @Getter
     @Builder
     public static class BoardDetailDto {
+
         private Long boardId;
+
         private String title;
+
         private String content;
+
         private String imageUrl;
+
         private BoardType boardType;
+
+        // ===== 스터디 게시판 =====
+        private StudyTag studyTag;
+
+        // ===== 프로젝트 게시판 =====
+        private ProjectStatus projectStatus;
+
+        private List<TechField> techFields;
+
+        private List<PlatformType> platformTypes;
+
         private String authorName;
+
         private Integer views;
+
         private Long likeCount;
+
         private Boolean isLiked;
+
         private LocalDateTime createdAt;
     }
 
     @Getter
     @Builder
     public static class BoardCreateResultDto {
+
         private Long boardId;
+
         private LocalDateTime createdAt;
     }
 
     @Getter
     @Builder
     public static class BoardUpdateResultDto {
+
         private Long boardId;
+
         private LocalDateTime updatedAt;
     }
 
     @Getter
     @Builder
     public static class BoardDeleteResultDto {
+
         private Long boardId;
+
         private LocalDateTime deletedAt;
     }
 
     @Getter
     @Builder
     public static class BoardPreviewDto {
+
         private Long boardId;
+
         private String title;
+
         private String content;
+
         private String imageUrl;
+
         private BoardType boardType;
+
+        // ===== 스터디 게시판 =====
+        private StudyTag studyTag;
+
+        // ===== 프로젝트 게시판 =====
+        private ProjectStatus projectStatus;
+
+        private List<TechField> techFields;
+
+        private List<PlatformType> platformTypes;
+
         private String writerName;
+
         private Long likeCount;
+
         private LocalDateTime createdAt;
     }
 
     @Getter
     @Builder
     public static class BoardPreviewListDto {
+
         private List<BoardPreviewDto> boardList;
+
         private Integer listSize;
+
         private Integer totalPage;
+
         private Long totalElements;
+
         private Boolean isFirst;
+
         private Boolean isLast;
     }
 }

--- a/src/main/java/root/git_turl/domain/board/entity/Board.java
+++ b/src/main/java/root/git_turl/domain/board/entity/Board.java
@@ -3,9 +3,12 @@ package root.git_turl.domain.board.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import root.git_turl.domain.board.enums.*;
 import root.git_turl.global.entity.BaseEntity;
-import root.git_turl.domain.board.enums.BoardType;
 import root.git_turl.domain.member.entity.Member;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Builder
@@ -40,11 +43,56 @@ public class Board extends BaseEntity {
     @JoinColumn(name = "member_id", nullable = false)
     private Member member;
 
-    public void update(String title, String content, String imageUrl, BoardType boardType) {
+    // ===== 스터디 게시판 =====
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "study_tag")
+    private StudyTag studyTag;
+
+    // ===== 프로젝트 게시판 =====
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "project_status")
+    private ProjectStatus projectStatus;
+
+    @ElementCollection(targetClass = TechField.class)
+    @Enumerated(EnumType.STRING)
+    @CollectionTable(
+            name = "board_tech_fields",
+            joinColumns = @JoinColumn(name = "board_id")
+    )
+    @Column(name = "tech_field")
+    private List<TechField> techFields = new ArrayList<>();
+
+    @ElementCollection(targetClass = PlatformType.class)
+    @Enumerated(EnumType.STRING)
+    @CollectionTable(
+            name = "board_platform_types",
+            joinColumns = @JoinColumn(name = "board_id")
+    )
+    @Column(name = "platform_type")
+    private List<PlatformType> platformTypes = new ArrayList<>();
+
+
+    public void update(
+            String title,
+            String content,
+            String imageUrl,
+            BoardType boardType,
+            StudyTag studyTag,
+            ProjectStatus projectStatus,
+            List<TechField> techFields,
+            List<PlatformType> platformTypes
+    ) {
         if (title != null) this.title = title;
         if (content != null) this.content = content;
         if (imageUrl != null) this.imageUrl = imageUrl;
         if (boardType != null) this.boardType = boardType;
+
+        this.studyTag = studyTag;
+        this.projectStatus = projectStatus;
+        this.techFields = techFields;
+        this.platformTypes = platformTypes;
     }
 
     public void increaseViews() {

--- a/src/main/java/root/git_turl/domain/board/enums/BoardSortType.java
+++ b/src/main/java/root/git_turl/domain/board/enums/BoardSortType.java
@@ -1,0 +1,6 @@
+package root.git_turl.domain.board.enums;
+
+public enum BoardSortType {
+    LATEST,
+    LIKE
+}

--- a/src/main/java/root/git_turl/domain/board/enums/PlatformType.java
+++ b/src/main/java/root/git_turl/domain/board/enums/PlatformType.java
@@ -1,0 +1,7 @@
+package root.git_turl.domain.board.enums;
+
+public enum PlatformType {
+    WEB,
+    APP,
+    ETC
+}

--- a/src/main/java/root/git_turl/domain/board/enums/ProjectStatus.java
+++ b/src/main/java/root/git_turl/domain/board/enums/ProjectStatus.java
@@ -1,0 +1,6 @@
+package root.git_turl.domain.board.enums;
+
+public enum ProjectStatus {
+    RECRUITING, // 모집중
+    CLOSED // 모집완료
+}

--- a/src/main/java/root/git_turl/domain/board/enums/StudyTag.java
+++ b/src/main/java/root/git_turl/domain/board/enums/StudyTag.java
@@ -1,0 +1,7 @@
+package root.git_turl.domain.board.enums;
+
+public enum StudyTag {
+    CERTIFICATE, // 자격증
+    CODING_TEST, // 코테
+    LANGUAGE // 어학
+}

--- a/src/main/java/root/git_turl/domain/board/enums/TechField.java
+++ b/src/main/java/root/git_turl/domain/board/enums/TechField.java
@@ -1,0 +1,8 @@
+package root.git_turl.domain.board.enums;
+
+public enum TechField {
+    BACKEND,
+    FRONTEND,
+    AI,
+    ETC
+}

--- a/src/main/java/root/git_turl/domain/board/repository/BoardRepository.java
+++ b/src/main/java/root/git_turl/domain/board/repository/BoardRepository.java
@@ -1,17 +1,44 @@
 package root.git_turl.domain.board.repository;
 
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import root.git_turl.domain.board.entity.Board;
 import root.git_turl.domain.board.enums.BoardType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.Optional;
+import root.git_turl.domain.board.enums.*;
 
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
     Page<Board> findAllByBoardType(BoardType boardType, Pageable pageable);
+
+    @Query("""
+        SELECT DISTINCT b
+        FROM Board b
+        LEFT JOIN b.techFields tf
+        LEFT JOIN b.platformTypes pt
+        LEFT JOIN BoardLike bl ON bl.board = b
+        WHERE (:boardType IS NULL OR b.boardType = :boardType)
+          AND (:studyTag IS NULL OR b.studyTag = :studyTag)
+          AND (:projectStatus IS NULL OR b.projectStatus = :projectStatus)
+          AND (:techField IS NULL OR tf = :techField)
+          AND (:platformType IS NULL OR pt = :platformType)
+        GROUP BY b
+        ORDER BY
+          CASE WHEN :sort = root.git_turl.domain.board.enums.BoardSortType.LIKE THEN COUNT(bl) END DESC,
+          b.createdAt DESC
+        """)
+    Page<Board> findBoardListWithFilters(
+            @Param("boardType") BoardType boardType,
+            @Param("studyTag") StudyTag studyTag,
+            @Param("projectStatus") ProjectStatus projectStatus,
+            @Param("techField") TechField techField,
+            @Param("platformType") PlatformType platformType,
+            @Param("sort") BoardSortType sort,
+            Pageable pageable
+    );
 
     //Optional<Board> findById(Long id);
 }

--- a/src/main/java/root/git_turl/domain/board/service/BoardCommandService.java
+++ b/src/main/java/root/git_turl/domain/board/service/BoardCommandService.java
@@ -9,6 +9,7 @@ import root.git_turl.domain.board.converter.BoardConverter;
 import root.git_turl.domain.board.dto.BoardReqDto;
 import root.git_turl.domain.board.dto.BoardResDto;
 import root.git_turl.domain.board.entity.Board;
+import root.git_turl.domain.board.enums.BoardType;
 import root.git_turl.domain.board.exception.BoardException;
 import root.git_turl.domain.board.repository.BoardRepository;
 import root.git_turl.domain.member.code.MemberErrorCode;
@@ -37,6 +38,8 @@ public class BoardCommandService {
         Member member = memberRepository.findById(currentMember.getId())
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
 
+        validateCreateRequest(request);
+
         String imageUrl = null;
 
         if (image != null && !image.isEmpty()) {
@@ -63,6 +66,10 @@ public class BoardCommandService {
         if (request.getTitle() == null
                 && request.getContent() == null
                 && request.getBoardType() == null
+                && request.getStudyTag() == null
+                && request.getProjectStatus() == null
+                && request.getTechFields() == null
+                && request.getPlatformTypes() == null
                 && (image == null || image.isEmpty())) {
             throw new BoardException(BoardErrorCode.NO_EDIT);
         }
@@ -71,6 +78,7 @@ public class BoardCommandService {
                 .orElseThrow(() -> new BoardException(BoardErrorCode.BOARD_NOT_FOUND));
 
         validateWriter(board, currentMember);
+        validateUpdateRequest(board, request);
 
         String imageUrl = board.getImageUrl();
 
@@ -82,11 +90,19 @@ public class BoardCommandService {
             }
         }
 
+        BoardType boardType = request.getBoardType() != null
+                ? request.getBoardType()
+                : board.getBoardType();
+
         board.update(
                 request.getTitle(),
                 request.getContent(),
                 imageUrl,
-                request.getBoardType()
+                boardType,
+                boardType == BoardType.STUDY ? request.getStudyTag() : null,
+                boardType == BoardType.PROJECT ? request.getProjectStatus() : null,
+                boardType == BoardType.PROJECT ? request.getTechFields() : null,
+                boardType == BoardType.PROJECT ? request.getPlatformTypes() : null
         );
 
         return BoardConverter.toUpdateResultDto(board);
@@ -105,6 +121,42 @@ public class BoardCommandService {
         boardRepository.delete(board);
 
         return BoardConverter.toDeleteResultDto(boardId);
+    }
+
+    private void validateCreateRequest(BoardReqDto.CreateBoardReqDto request) {
+        if (request.getBoardType() == BoardType.STUDY) {
+            if (request.getStudyTag() == null) {
+                throw new BoardException(BoardErrorCode.INVALID_BOARD_TYPE);
+            }
+        }
+
+        if (request.getBoardType() == BoardType.PROJECT) {
+            if (request.getProjectStatus() == null
+                    || request.getTechFields() == null || request.getTechFields().isEmpty()
+                    || request.getPlatformTypes() == null || request.getPlatformTypes().isEmpty()) {
+                throw new BoardException(BoardErrorCode.INVALID_BOARD_TYPE);
+            }
+        }
+    }
+
+    private void validateUpdateRequest(Board board, BoardReqDto.UpdateDto request) {
+        BoardType boardType = request.getBoardType() != null
+                ? request.getBoardType()
+                : board.getBoardType();
+
+        if (boardType == BoardType.STUDY) {
+            if (request.getStudyTag() == null && board.getStudyTag() == null) {
+                throw new BoardException(BoardErrorCode.INVALID_BOARD_TYPE);
+            }
+        }
+
+        if (boardType == BoardType.PROJECT) {
+            if ((request.getProjectStatus() == null && board.getProjectStatus() == null)
+                    || (request.getTechFields() == null && (board.getTechFields() == null || board.getTechFields().isEmpty()))
+                    || (request.getPlatformTypes() == null && (board.getPlatformTypes() == null || board.getPlatformTypes().isEmpty()))) {
+                throw new BoardException(BoardErrorCode.INVALID_BOARD_TYPE);
+            }
+        }
     }
 
     private void validateWriter(Board board, Member currentMember) {

--- a/src/main/java/root/git_turl/domain/board/service/BoardQueryService.java
+++ b/src/main/java/root/git_turl/domain/board/service/BoardQueryService.java
@@ -10,7 +10,7 @@ import root.git_turl.domain.board.code.BoardErrorCode;
 import root.git_turl.domain.board.converter.BoardConverter;
 import root.git_turl.domain.board.dto.BoardResDto;
 import root.git_turl.domain.board.entity.Board;
-import root.git_turl.domain.board.enums.BoardType;
+import root.git_turl.domain.board.enums.*;
 import root.git_turl.domain.board.exception.BoardException;
 import root.git_turl.domain.board.repository.BoardLikeRepository;
 import root.git_turl.domain.board.repository.BoardRepository;
@@ -25,16 +25,26 @@ public class BoardQueryService {
     private final BoardLikeRepository boardLikeRepository;
 
     @Transactional(readOnly = true)
-    public BoardResDto.BoardPreviewListDto getBoardList(Integer page, BoardType boardType) {
-        PageRequest pageRequest = PageRequest.of(
-                page,
-                10,
-                Sort.by(Sort.Direction.DESC, "createdAt")
-        );
+    public BoardResDto.BoardPreviewListDto getBoardList(
+            Integer page,
+            BoardType boardType,
+            StudyTag studyTag,
+            ProjectStatus projectStatus,
+            TechField techField,
+            PlatformType platformType,
+            BoardSortType sort
+    ) {
+        PageRequest pageRequest = PageRequest.of(page, 10);
 
-        Page<Board> boardPage = boardType == null
-                ? boardRepository.findAll(pageRequest)
-                : boardRepository.findAllByBoardType(boardType, pageRequest);
+        Page<Board> boardPage = boardRepository.findBoardListWithFilters(
+                boardType,
+                studyTag,
+                projectStatus,
+                techField,
+                platformType,
+                sort,
+                pageRequest
+        );
 
         return BoardConverter.toBoardPreviewListDto(
                 boardPage,


### PR DESCRIPTION
## 💡 관련 이슈
- close #70 

<br>

## 📝 작업 내용
> 
- 스터디 게시판 태그 기능 추가
   - 자격증 / 코딩테스트 / 어학
- 프로젝트 게시판 태그 기능 추가
   - 모집중 / 모집완료
- 프로젝트 게시판 기술 스택 및 플랫폼 다중 선택 기능 추가
   - BACKEND / FRONTEND / AI / ETC
   - WEB / APP / ETC
- 게시글 생성/수정 DTO 및 엔티티 구조 변경
- 게시글 목록 조회 필터 기능 추가
   - 스터디 태그별 조회
   - 기술 스택별 조회
   - 플랫폼별 조회
   - 최신순 / 좋아요순 정렬

<br>

## 🛠️ 기타
> 기술 스택/플랫폼은 `@ElementCollection` 기반 다중 선택 구조로 변경했습니다
