### PR TITLE
[FIX] 배포 서버에서 질문 생성 안 되는 문제

### DIFF
--- a/src/main/java/root/git_turl/domain/answer/dto/AnswerVoiceSavedEvent.java
+++ b/src/main/java/root/git_turl/domain/answer/dto/AnswerVoiceSavedEvent.java
@@ -1,0 +1,8 @@
+package root.git_turl.domain.answer.dto;
+
+public record AnswerVoiceSavedEvent(
+        String questionContent,
+        Integer questionTime,
+        String voiceFileUrl,
+        Long answerId
+) {}

--- a/src/main/java/root/git_turl/domain/answer/service/AnswerService.java
+++ b/src/main/java/root/git_turl/domain/answer/service/AnswerService.java
@@ -4,14 +4,12 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import root.git_turl.domain.answer.converter.AnswerConverter;
-import root.git_turl.domain.answer.dto.AnswerReqDto;
-import root.git_turl.domain.answer.dto.AnswerResDto;
-import root.git_turl.domain.answer.dto.Feedback;
-import root.git_turl.domain.answer.dto.VoiceFeedback;
+import root.git_turl.domain.answer.dto.*;
 import root.git_turl.domain.answer.entity.Answer;
 import root.git_turl.domain.answer.enums.AnswerType;
 import root.git_turl.domain.answer.enums.Status;
@@ -44,6 +42,7 @@ public class AnswerService {
     private final GptService gptService;
     private final AsyncAnswerService asyncAnswerService;
     private final AwsFileService awsFileService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public List<AnswerResDto.TextAnswer> getAnswerList(Member currentMember, Long questionId) {
@@ -137,8 +136,7 @@ public class AnswerService {
         }
         Answer answer = AnswerConverter.toVoiceAnswer(voiceFileUrl, question);
         answerRepository.save(answer);
-
-        asyncAnswerService.saveAnswerVoice(question.getContent(), question.getTime(), voiceFileUrl, answer.getId());
+        eventPublisher.publishEvent(new AnswerVoiceSavedEvent(question.getContent(), question.getTime(), voiceFileUrl, answer.getId()));
     }
 
     @Transactional

--- a/src/main/java/root/git_turl/domain/answer/service/AsyncAnswerService.java
+++ b/src/main/java/root/git_turl/domain/answer/service/AsyncAnswerService.java
@@ -5,7 +5,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import root.git_turl.domain.answer.dto.AnswerVoiceSavedEvent;
 import root.git_turl.domain.answer.dto.VoiceFeedback;
 import root.git_turl.domain.answer.entity.Answer;
 import root.git_turl.domain.answer.exception.AnswerException;
@@ -15,8 +19,6 @@ import root.git_turl.domain.report.enums.GenerationStatus;
 import root.git_turl.global.util.BuildPrompt;
 import root.git_turl.infrastructure.openai.GptService;
 import root.git_turl.infrastructure.openai.WhisperService;
-
-import java.io.IOException;
 
 @Service
 @RequiredArgsConstructor
@@ -29,20 +31,18 @@ public class AsyncAnswerService {
     private final ObjectMapper objectMapper;
 
     @Async
-    @Transactional
-    public void saveAnswerVoice(
-            String questionContent, Integer questionTime,
-            String voiceFileUrl, Long answerId
-    ) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void saveAnswerVoice(AnswerVoiceSavedEvent event) {
 
-        Answer answer = answerRepository.findById(answerId)
+        Answer answer = answerRepository.findById(event.answerId())
                 .orElseThrow(() -> new AnswerException(AnswerErrorCode.NOT_FOUND));
 
         // 음성 -> 텍스트 변환
-        String textAnswer = whisperService.transcribe(voiceFileUrl, answer);
+        String textAnswer = whisperService.transcribe(event.voiceFileUrl(), answer);
 
         // 답변 피드백 생성
-        String prompt = buildPrompt.buildSummaryAndFeedbackPrompt(textAnswer, questionContent, questionTime);
+        String prompt = buildPrompt.buildSummaryAndFeedbackPrompt(textAnswer, event.questionContent(), event.questionTime());
         VoiceFeedback response = gptService.makeVoiceFeedback(prompt);
 
         // 음성 답변, 피드백 저장

--- a/src/main/java/root/git_turl/domain/question/dto/QuestionSavedEvent.java
+++ b/src/main/java/root/git_turl/domain/question/dto/QuestionSavedEvent.java
@@ -1,0 +1,9 @@
+package root.git_turl.domain.question.dto;
+
+import java.util.List;
+
+public record QuestionSavedEvent(
+        Long reportId,
+        Integer count,
+        List<Long> questionIds
+) {}

--- a/src/main/java/root/git_turl/domain/question/service/AsyncQuestionService.java
+++ b/src/main/java/root/git_turl/domain/question/service/AsyncQuestionService.java
@@ -4,9 +4,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import root.git_turl.domain.question.converter.QuestionConverter;
 import root.git_turl.domain.question.dto.QuestionContent;
+import root.git_turl.domain.question.dto.QuestionSavedEvent;
 import root.git_turl.domain.question.entity.Question;
 import root.git_turl.domain.question.exception.QuestionException;
 import root.git_turl.domain.question.exception.code.QuestionErrorCode;
@@ -34,33 +38,34 @@ public class AsyncQuestionService {
     private final QuestionRepository questionRepository;
 
     @Async
-    @Transactional
-    public void makeQuestion(Long reportId, Integer count, List<Long> questionIdLists) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void makeQuestion(QuestionSavedEvent event) {
         log.info("async 시작");
 
-        Report report = reportRepository.findById(reportId)
+        Report report = reportRepository.findById(event.reportId())
                 .orElseThrow(() -> new ReportException(ReportErrorCode.REPORT_NOT_FOUND));
         List<Question> questions =
-                questionRepository.findAllById(questionIdLists);
+                questionRepository.findAllById(event.questionIds());
         log.info("questionList={}", questions.stream().map(q -> q.getId()).toList());
         try {
-            String prompt = buildPrompt.buildQuestionPrompt(report, count);
+            String prompt = buildPrompt.buildQuestionPrompt(report, event.count());
             log.info("prompt 생성 완료");
             Map<String,Integer> contents = gptService.makeQuestions(prompt).getQuestions();
             log.info("gpt raw response={}", contents);
             List<String> keys = new ArrayList<>(contents.keySet());
-            log.info("questionIdList={}", questionIdLists);
+            log.info("questionIdList={}", event.questionIds());
 
             for (int i=0; i<questions.size(); i++) {
-                log.info("questionId={}", questionIdLists);
                 questions.get(i).updateContent(keys.get(i));
                 questions.get(i).updateTime(contents.get(keys.get(i)));
                 questions.get(i).updateStatus(GenerationStatus.DONE);
             }
+            questionRepository.saveAll(questions);
             log.info("update 완료");
         } catch (Exception e) {
             log.error("비동기 실패", e);
-            for (int i=0; i<count; i++) {
+            for (int i=0; i<event.count(); i++) {
                 questions.get(i).updateStatus(GenerationStatus.FAIL);
             }
         }

--- a/src/main/java/root/git_turl/domain/question/service/QuestionService.java
+++ b/src/main/java/root/git_turl/domain/question/service/QuestionService.java
@@ -2,6 +2,7 @@ package root.git_turl.domain.question.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -15,6 +16,7 @@ import root.git_turl.domain.question.converter.QuestionConverter;
 import root.git_turl.domain.question.dto.QuestionContent;
 import root.git_turl.domain.question.dto.QuestionReqDto;
 import root.git_turl.domain.question.dto.QuestionResDto;
+import root.git_turl.domain.question.dto.QuestionSavedEvent;
 import root.git_turl.domain.question.entity.Question;
 import root.git_turl.domain.question.exception.QuestionException;
 import root.git_turl.domain.question.exception.code.QuestionErrorCode;
@@ -37,7 +39,7 @@ public class QuestionService {
     private final ReportRepository reportRepository;
     private final MemberRepository memberRepository;
     private final QuestionRepository questionRepository;
-    private final AsyncQuestionService asyncQuestionService;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public QuestionResDto.QuestionId saveQuestion(Member currentMember, Long reportId, QuestionReqDto.QuestionInfo dto) {
@@ -53,7 +55,7 @@ public class QuestionService {
         }
         log.info("questions id" + questions);
         questionRepository.saveAll(questions);
-        asyncQuestionService.makeQuestion(reportId, dto.getQuestionCount(), questions.stream().map(Question::getId).toList());
+        eventPublisher.publishEvent(new QuestionSavedEvent(reportId, dto.getQuestionCount(), questions.stream().map(Question::getId).toList()));
         return QuestionConverter.toQuestionIdList(questions);
     }
 

--- a/src/main/java/root/git_turl/domain/report/dto/ReportSavedEvent.java
+++ b/src/main/java/root/git_turl/domain/report/dto/ReportSavedEvent.java
@@ -1,0 +1,8 @@
+package root.git_turl.domain.report.dto;
+
+public record ReportSavedEvent (
+    Long reportId,
+    String email,
+    String githubId,
+    ReportReqDto.Repo dto
+) {}

--- a/src/main/java/root/git_turl/domain/report/service/ReportAsyncService.java
+++ b/src/main/java/root/git_turl/domain/report/service/ReportAsyncService.java
@@ -6,11 +6,15 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 import root.git_turl.domain.member.entity.Member;
 import root.git_turl.domain.report.code.ReportErrorCode;
 import root.git_turl.domain.report.dto.GitAnalysisResult;
 import root.git_turl.domain.report.dto.ReportReqDto;
+import root.git_turl.domain.report.dto.ReportSavedEvent;
 import root.git_turl.domain.report.dto.commit.GitCommit;
 import root.git_turl.domain.report.dto.reportDetail.ReportWrapper;
 import root.git_turl.domain.report.entity.Report;
@@ -39,14 +43,15 @@ public class ReportAsyncService {
     private final GitCloneService gitCloneService;
 
     @Async
-    @Transactional
-    public void generateReport(Long reportId, Member currentMember, ReportReqDto.Repo dto) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void generateReport(ReportSavedEvent event) {
         log.info("비동기 실행됨: {}", Thread.currentThread().getName());
-        String email = currentMember.getEmail();
-        String gitUrl = GitRepoParser.getRepoLink(dto.getFullName());
+        String email = event.email();
+        String gitUrl = GitRepoParser.getRepoLink(event.dto().getFullName());
         String repoPath = gitCloneService.cloneRepository(gitUrl);
 
-        Report report = reportRepository.findById(reportId)
+        Report report = reportRepository.findById(event.reportId())
                 .orElseThrow();
 
         report.updateGenerationStatus(GenerationStatus.PROCESSING);
@@ -55,7 +60,7 @@ public class ReportAsyncService {
         try {
             List<GitCommit> commits = gitLogParser.getCommits(repoPath);
             List<GitCommit> userCommits = commits.stream()
-                    .filter(c -> c.getAuthorEmail().equals(email) || c.getAuthorEmail().contains(currentMember.getGithubId()))
+                    .filter(c -> c.getAuthorEmail().equals(email) || c.getAuthorEmail().contains(event.githubId()))
                     .toList();
 
             GitAnalysisResult result = gitAnalysisService.analyze(GitRepoParser.getRepoFullName(gitUrl), repoPath, commits, userCommits);

--- a/src/main/java/root/git_turl/domain/report/service/ReportService.java
+++ b/src/main/java/root/git_turl/domain/report/service/ReportService.java
@@ -1,6 +1,7 @@
 package root.git_turl.domain.report.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -13,6 +14,7 @@ import root.git_turl.domain.report.converter.ReportConverter;
 import root.git_turl.domain.report.dto.GithubRepoResponse;
 import root.git_turl.domain.report.dto.ReportReqDto;
 import root.git_turl.domain.report.dto.ReportResDto;
+import root.git_turl.domain.report.dto.ReportSavedEvent;
 import root.git_turl.domain.report.entity.Report;
 import root.git_turl.domain.report.enums.GenerationStatus;
 import root.git_turl.domain.report.enums.Status;
@@ -35,6 +37,7 @@ public class ReportService {
     private final ReportAsyncService reportAsyncService;
     private final ReportRepository reportRepository;
     private final QuestionRepository questionRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
     public List<ReportResDto.RepoInfo> getRepoList(String token) {
@@ -48,7 +51,7 @@ public class ReportService {
     public ReportResDto.ReportId postReport(Member currentMember, ReportReqDto.Repo dto) {
         Report report = ReportConverter.toReport(currentMember.getGithubId(), dto.getFullName(), currentMember);
         reportRepository.save(report);
-        reportAsyncService.generateReport(report.getId(), currentMember, dto);
+        eventPublisher.publishEvent(new ReportSavedEvent(report.getId(), currentMember.getEmail(), currentMember.getGithubId(), dto));
         return ReportConverter.toReportId(report);
     }
 


### PR DESCRIPTION
## 💡 관련 이슈
- close #74

<br>

## 📝 작업 내용
- 문제점
원래 동기 부분에서
1. Question 빈 객체 생성
2. 이를 JPA 레포에 저장
3. 비동기 처리 실행

이 순서인데, 2번이 다 실행되기 전에 3번이 빠르게 실행되면 question이 업데이트 되지 않아서 질문 생성이 제대로 안 됨.

- 해결 방법
@TransactionalEventListener
이벤트 리스너를 적용하여 질문 객체가 db에 커밋된 후 비동기 처리하도록 수정하였다.

<br>

## 🛠️ 기타
[블로그](https://velog.io/@icebox127/JPA-%EB%B9%84%EB%8F%99%EA%B8%B0-%EC%B2%98%EB%A6%AC-%EA%B0%80%EB%81%94-DB%EC%97%90-%EC%A0%80%EC%9E%A5-%EC%95%88-%EB%90%98-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0)
