### PR TITLE
[Feat] 자신/타인 게시글/댓글 조회

### DIFF
--- a/src/main/java/root/git_turl/domain/board/controller/BoardControllerDocs.java
+++ b/src/main/java/root/git_turl/domain/board/controller/BoardControllerDocs.java
@@ -85,4 +85,26 @@ public interface BoardControllerDocs {
             @CurrentUser @Parameter(hidden = true) Member member,
             @PathVariable Long boardId
     );
+
+    @Operation(
+            summary = "내가 작성한 게시글 조회",
+            description = "로그인한 사용자가 작성한 게시글 목록을 조회합니다."
+    )
+    ApiResponse<BoardResDto.BoardPreviewListDto> getMyBoards(
+            @CurrentUser @Parameter(hidden = true) Member member,
+
+            @RequestParam(defaultValue = "0")
+            Integer page
+    );
+
+    @Operation(
+            summary = "특정 회원이 작성한 게시글 조회",
+            description = "특정 회원이 작성한 게시글 목록을 조회합니다."
+    )
+    ApiResponse<BoardResDto.BoardPreviewListDto> getMemberBoards(
+            @PathVariable Long memberId,
+
+            @RequestParam(defaultValue = "0")
+            Integer page
+    );
 }

--- a/src/main/java/root/git_turl/domain/board/controller/BoardRestController.java
+++ b/src/main/java/root/git_turl/domain/board/controller/BoardRestController.java
@@ -127,4 +127,26 @@ public class BoardRestController implements BoardControllerDocs {
                 boardQueryService.getBoardDetail(member, boardId)
         );
     }
+
+    @GetMapping("/me")
+    public ApiResponse<BoardResDto.BoardPreviewListDto> getMyBoards(
+            @CurrentUser Member member,
+            @RequestParam(defaultValue = "0") Integer page
+    ) {
+        return ApiResponse.onSuccess(
+                BoardSuccessCode.BOARD_LIST_FOUND,
+                boardQueryService.getMyBoards(member, page)
+        );
+    }
+
+    @GetMapping("/members/{memberId}")
+    public ApiResponse<BoardResDto.BoardPreviewListDto> getMemberBoards(
+            @PathVariable Long memberId,
+            @RequestParam(defaultValue = "0") Integer page
+    ) {
+        return ApiResponse.onSuccess(
+                BoardSuccessCode.BOARD_LIST_FOUND,
+                boardQueryService.getMemberBoards(memberId, page)
+        );
+    }
 }

--- a/src/main/java/root/git_turl/domain/board/repository/BoardRepository.java
+++ b/src/main/java/root/git_turl/domain/board/repository/BoardRepository.java
@@ -95,4 +95,28 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
             @Param("platformType") PlatformType platformType,
             Pageable pageable
     );
+
+    @Query(
+            value = """
+    SELECT DISTINCT b AS board, COUNT(DISTINCT bl.id) AS likeCount
+    FROM Board b
+    JOIN b.member m
+    LEFT JOIN b.recruitStacks rs
+    LEFT JOIN b.projectStacks ps
+    LEFT JOIN b.platformTypes pt
+    LEFT JOIN BoardLike bl ON bl.board = b
+    WHERE b.member.id = :memberId
+    GROUP BY b
+    ORDER BY b.createdAt DESC
+""",
+            countQuery = """
+    SELECT COUNT(DISTINCT b)
+    FROM Board b
+    WHERE b.member.id = :memberId
+"""
+    )
+    Page<BoardPreviewProjection> findBoardsByMemberIdOrderByLatest(
+            @Param("memberId") Long memberId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/root/git_turl/domain/board/service/BoardQueryService.java
+++ b/src/main/java/root/git_turl/domain/board/service/BoardQueryService.java
@@ -90,4 +90,20 @@ public class BoardQueryService {
                 isLiked
         );
     }
+
+    @Transactional(readOnly = true)
+    public BoardResDto.BoardPreviewListDto getMyBoards(Member member, Integer page) {
+        return getMemberBoards(member.getId(), page);
+    }
+
+    @Transactional(readOnly = true)
+    public BoardResDto.BoardPreviewListDto getMemberBoards(Long memberId, Integer page) {
+        Page<BoardPreviewProjection> boardPage =
+                boardRepository.findBoardsByMemberIdOrderByLatest(
+                        memberId,
+                        PageRequest.of(page, 10)
+                );
+
+        return BoardConverter.toBoardPreviewListDto(boardPage);
+    }
 }

--- a/src/main/java/root/git_turl/domain/comment/controller/CommentController.java
+++ b/src/main/java/root/git_turl/domain/comment/controller/CommentController.java
@@ -73,4 +73,26 @@ public class CommentController implements CommentControllerDocs {
                 commentQueryService.getCommentList(member, boardId, page)
         );
     }
+
+    @GetMapping("/comments/me")
+    public ApiResponse<CommentResDto.MyCommentPreviewListDto> getMyComments(
+            @CurrentUser Member member,
+            @RequestParam(defaultValue = "0") Integer page
+    ) {
+        return ApiResponse.onSuccess(
+                CommentSuccessCode.COMMENT_LIST_FOUND,
+                commentQueryService.getMyComments(member, page)
+        );
+    }
+
+    @GetMapping("/comments/members/{memberId}")
+    public ApiResponse<CommentResDto.MyCommentPreviewListDto> getMemberComments(
+            @PathVariable Long memberId,
+            @RequestParam(defaultValue = "0") Integer page
+    ) {
+        return ApiResponse.onSuccess(
+                CommentSuccessCode.COMMENT_LIST_FOUND,
+                commentQueryService.getMemberComments(memberId, page)
+        );
+    }
 }

--- a/src/main/java/root/git_turl/domain/comment/controller/CommentControllerDocs.java
+++ b/src/main/java/root/git_turl/domain/comment/controller/CommentControllerDocs.java
@@ -52,4 +52,26 @@ public interface CommentControllerDocs {
             @PathVariable Long boardId,
             @RequestParam(defaultValue = "0") Integer page
     );
+
+    @Operation(
+            summary = "내가 작성한 댓글 조회",
+            description = "로그인한 사용자가 작성한 댓글 목록을 조회합니다."
+    )
+    ApiResponse<CommentResDto.MyCommentPreviewListDto> getMyComments(
+            @CurrentUser @Parameter(hidden = true) Member member,
+
+            @RequestParam(defaultValue = "0")
+            Integer page
+    );
+
+    @Operation(
+            summary = "특정 회원이 작성한 댓글 조회",
+            description = "특정 회원이 작성한 댓글 목록을 조회합니다."
+    )
+    ApiResponse<CommentResDto.MyCommentPreviewListDto> getMemberComments(
+            @PathVariable Long memberId,
+
+            @RequestParam(defaultValue = "0")
+            Integer page
+    );
 }

--- a/src/main/java/root/git_turl/domain/comment/converter/CommentConverter.java
+++ b/src/main/java/root/git_turl/domain/comment/converter/CommentConverter.java
@@ -7,6 +7,7 @@ import root.git_turl.domain.comment.dto.CommentReqDto;
 import root.git_turl.domain.comment.dto.CommentResDto;
 import root.git_turl.domain.comment.entity.Comment;
 import root.git_turl.domain.comment.repository.CommentLikeRepository;
+import root.git_turl.domain.comment.repository.MyCommentProjection;
 import root.git_turl.domain.member.entity.Member;
 
 import java.time.LocalDateTime;
@@ -113,6 +114,37 @@ public class CommentConverter {
                 .toList();
 
         return CommentResDto.CommentPreviewListDto.builder()
+                .commentList(commentList)
+                .listSize(commentList.size())
+                .totalPage(commentPage.getTotalPages())
+                .totalElements(commentPage.getTotalElements())
+                .isFirst(commentPage.isFirst())
+                .isLast(commentPage.isLast())
+                .build();
+    }
+
+    public static CommentResDto.MyCommentPreviewDto toMyCommentPreviewDto(
+            MyCommentProjection projection
+    ) {
+        return CommentResDto.MyCommentPreviewDto.builder()
+                .commentId(projection.getCommentId())
+                .boardId(projection.getBoardId())
+                .boardTitle(projection.getBoardTitle())
+                .boardType(projection.getBoardType())
+                .content(projection.getContent())
+                .likeCount(projection.getLikeCount())
+                .createdAt(projection.getCreatedAt())
+                .build();
+    }
+
+    public static CommentResDto.MyCommentPreviewListDto toMyCommentPreviewListDto(
+            Page<MyCommentProjection> commentPage
+    ) {
+        List<CommentResDto.MyCommentPreviewDto> commentList = commentPage.stream()
+                .map(CommentConverter::toMyCommentPreviewDto)
+                .toList();
+
+        return CommentResDto.MyCommentPreviewListDto.builder()
                 .commentList(commentList)
                 .listSize(commentList.size())
                 .totalPage(commentPage.getTotalPages())

--- a/src/main/java/root/git_turl/domain/comment/dto/CommentResDto.java
+++ b/src/main/java/root/git_turl/domain/comment/dto/CommentResDto.java
@@ -2,6 +2,7 @@ package root.git_turl.domain.comment.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import root.git_turl.domain.board.enums.BoardType;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -49,6 +50,29 @@ public class CommentResDto {
     @Builder
     public static class CommentPreviewListDto {
         private List<CommentPreviewDto> commentList;
+        private Integer listSize;
+        private Integer totalPage;
+        private Long totalElements;
+        private Boolean isFirst;
+        private Boolean isLast;
+    }
+
+    @Getter
+    @Builder
+    public static class MyCommentPreviewDto {
+        private Long commentId;
+        private Long boardId;
+        private String boardTitle;
+        private BoardType boardType;
+        private String content;
+        private Long likeCount;
+        private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @Builder
+    public static class MyCommentPreviewListDto {
+        private List<MyCommentPreviewDto> commentList;
         private Integer listSize;
         private Integer totalPage;
         private Long totalElements;

--- a/src/main/java/root/git_turl/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/root/git_turl/domain/comment/repository/CommentRepository.java
@@ -37,4 +37,34 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
             @Param("board") Board board,
             Pageable pageable
     );
+
+    @Query(
+            value = """
+    SELECT
+        c.id AS commentId,
+        b.id AS boardId,
+        b.title AS boardTitle,
+        b.boardType AS boardType,
+        c.content AS content,
+        COUNT(DISTINCT cl.id) AS likeCount,
+        c.createdAt AS createdAt
+    FROM Comment c
+    JOIN c.board b
+    LEFT JOIN CommentLike cl ON cl.comment = c
+    WHERE c.member.id = :memberId
+      AND c.deletedAt IS NULL
+    GROUP BY c.id, b.id, b.title, b.boardType, c.content, c.createdAt
+    ORDER BY c.createdAt DESC
+""",
+            countQuery = """
+    SELECT COUNT(c)
+    FROM Comment c
+    WHERE c.member.id = :memberId
+      AND c.deletedAt IS NULL
+"""
+    )
+    Page<MyCommentProjection> findCommentsByMemberId(
+            @Param("memberId") Long memberId,
+            Pageable pageable
+    );
 }

--- a/src/main/java/root/git_turl/domain/comment/repository/MyCommentProjection.java
+++ b/src/main/java/root/git_turl/domain/comment/repository/MyCommentProjection.java
@@ -1,0 +1,15 @@
+package root.git_turl.domain.comment.repository;
+
+import root.git_turl.domain.board.enums.BoardType;
+
+import java.time.LocalDateTime;
+
+public interface MyCommentProjection {
+    Long getCommentId();
+    Long getBoardId();
+    String getBoardTitle();
+    BoardType getBoardType();
+    String getContent();
+    Long getLikeCount();
+    LocalDateTime getCreatedAt();
+}

--- a/src/main/java/root/git_turl/domain/comment/service/CommentQueryService.java
+++ b/src/main/java/root/git_turl/domain/comment/service/CommentQueryService.java
@@ -15,6 +15,7 @@ import root.git_turl.domain.comment.dto.CommentResDto;
 import root.git_turl.domain.comment.entity.Comment;
 import root.git_turl.domain.comment.repository.CommentLikeRepository;
 import root.git_turl.domain.comment.repository.CommentRepository;
+import root.git_turl.domain.comment.repository.MyCommentProjection;
 import root.git_turl.domain.member.entity.Member;
 
 @Service
@@ -49,5 +50,21 @@ public class CommentQueryService {
                 currentMember,
                 commentLikeRepository
         );
+    }
+
+    @Transactional(readOnly = true)
+    public CommentResDto.MyCommentPreviewListDto getMemberComments(Long memberId, Integer page) {
+        Page<MyCommentProjection> commentPage =
+                commentRepository.findCommentsByMemberId(
+                        memberId,
+                        PageRequest.of(page, 10)
+                );
+
+        return CommentConverter.toMyCommentPreviewListDto(commentPage);
+    }
+
+    @Transactional(readOnly = true)
+    public CommentResDto.MyCommentPreviewListDto getMyComments(Member member, Integer page) {
+        return getMemberComments(member.getId(), page);
     }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- close #62 

<br>

## 📝 작업 내용
- 내가 작성한 게시글 조회 API 추가
- 특정 회원이 작성한 게시글 조회 API 추가
- 내가 작성한 댓글 조회 API 추가
- 특정 회원이 작성한 댓글 조회 API 추가

<br>

## 🛠️ 기타
> 프로필 화면(작성한 게시글/댓글 목록) 조회 기능 구현
