### PR TITLE
[Feat] 추천 프로젝트 조회

### DIFF
--- a/src/main/java/root/git_turl/domain/board/controller/BoardControllerDocs.java
+++ b/src/main/java/root/git_turl/domain/board/controller/BoardControllerDocs.java
@@ -14,6 +14,8 @@ import root.git_turl.domain.member.entity.Member;
 import root.git_turl.global.annotation.CurrentUser;
 import root.git_turl.global.apiPayload.ApiResponse;
 
+import java.util.List;
+
 public interface BoardControllerDocs {
 
     @Operation(
@@ -106,5 +108,13 @@ public interface BoardControllerDocs {
 
             @RequestParam(defaultValue = "0")
             Integer page
+    );
+
+    @Operation(
+            summary = "추천 프로젝트 조회",
+            description = "로그인한 사용자의 관심 기술스택과 프로젝트 구인스택을 기반으로 추천 프로젝트 게시글을 최대 3개 조회합니다."
+    )
+    ApiResponse<List<BoardResDto.RecommendProjectDto>> getRecommendProjects(
+            @CurrentUser @Parameter(hidden = true) Member member
     );
 }

--- a/src/main/java/root/git_turl/domain/board/controller/BoardRestController.java
+++ b/src/main/java/root/git_turl/domain/board/controller/BoardRestController.java
@@ -19,6 +19,8 @@ import root.git_turl.global.apiPayload.ApiResponse;
 import root.git_turl.domain.board.dto.BoardReqDto;
 import root.git_turl.domain.board.dto.BoardResDto;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/v1/boards")
 @RequiredArgsConstructor
@@ -147,6 +149,16 @@ public class BoardRestController implements BoardControllerDocs {
         return ApiResponse.onSuccess(
                 BoardSuccessCode.BOARD_LIST_FOUND,
                 boardQueryService.getMemberBoards(memberId, page)
+        );
+    }
+
+    @GetMapping("/projects/recommend")
+    public ApiResponse<List<BoardResDto.RecommendProjectDto>> getRecommendProjects(
+            @CurrentUser Member member
+    ) {
+        return ApiResponse.onSuccess(
+                BoardSuccessCode.BOARD_LIST_FOUND,
+                boardQueryService.getRecommendProjects(member)
         );
     }
 }

--- a/src/main/java/root/git_turl/domain/board/converter/BoardConverter.java
+++ b/src/main/java/root/git_turl/domain/board/converter/BoardConverter.java
@@ -154,4 +154,19 @@ public class BoardConverter {
                 .isLast(boardPage.isLast())
                 .build();
     }
+
+    public BoardResDto.RecommendProjectDto toRecommendProjectDto(
+            Board board,
+            Long likeCount
+    ) {
+        return BoardResDto.RecommendProjectDto.builder()
+                .boardId(board.getId())
+                .title(board.getTitle())
+                .content(board.getContent())
+                .recruitStacks(board.getRecruitStacks())
+                .likeCount(likeCount)
+                .views(board.getViews())
+                .recruitCount(board.getRecruitCount())
+                .build();
+    }
 }

--- a/src/main/java/root/git_turl/domain/board/dto/BoardResDto.java
+++ b/src/main/java/root/git_turl/domain/board/dto/BoardResDto.java
@@ -137,4 +137,16 @@ public class BoardResDto {
 
         private Boolean isLast;
     }
+
+    @Getter
+    @Builder
+    public static class RecommendProjectDto {
+        private Long boardId;
+        private String title;
+        private String content;
+        private List<TechStack> recruitStacks;
+        private Long likeCount;
+        private Integer views;
+        private Integer recruitCount;
+    }
 }

--- a/src/main/java/root/git_turl/domain/board/repository/BoardRepository.java
+++ b/src/main/java/root/git_turl/domain/board/repository/BoardRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.repository.query.Param;
 import root.git_turl.domain.board.entity.Board;
 import root.git_turl.domain.board.enums.*;
 
+import java.util.List;
+
 public interface BoardRepository extends JpaRepository<Board, Long> {
 
     Page<Board> findAllByBoardType(BoardType boardType, Pageable pageable);
@@ -119,4 +121,27 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
             @Param("memberId") Long memberId,
             Pageable pageable
     );
+
+    @Query("""
+    SELECT DISTINCT b
+    FROM Board b
+    LEFT JOIN b.recruitStacks rs
+    WHERE b.boardType = root.git_turl.domain.board.enums.BoardType.PROJECT
+      AND b.projectStatus = root.git_turl.domain.board.enums.ProjectStatus.RECRUITING
+      AND rs IN :techStacks
+    ORDER BY function('rand')
+""")
+    List<Board> findRecommendProjectsByTechStacks(
+            @Param("techStacks") List<TechStack> techStacks,
+            Pageable pageable
+    );
+
+    @Query("""
+    SELECT b
+    FROM Board b
+    WHERE b.boardType = root.git_turl.domain.board.enums.BoardType.PROJECT
+      AND b.projectStatus = root.git_turl.domain.board.enums.ProjectStatus.RECRUITING
+    ORDER BY function('rand')
+""")
+    List<Board> findRecommendProjectsAll(Pageable pageable);
 }

--- a/src/main/java/root/git_turl/domain/board/service/BoardQueryService.java
+++ b/src/main/java/root/git_turl/domain/board/service/BoardQueryService.java
@@ -16,6 +16,8 @@ import root.git_turl.domain.board.repository.BoardPreviewProjection;
 import root.git_turl.domain.board.repository.BoardRepository;
 import root.git_turl.domain.member.entity.Member;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class BoardQueryService {
@@ -105,5 +107,110 @@ public class BoardQueryService {
                 );
 
         return BoardConverter.toBoardPreviewListDto(boardPage);
+    }
+
+    @Transactional(readOnly = true)
+    public List<BoardResDto.RecommendProjectDto> getRecommendProjects(Member member) {
+
+        List<root.git_turl.domain.board.enums.TechStack> boardTechStacks =
+                convertToBoardTechStacks(member);
+
+        List<Board> boards;
+
+        if (boardTechStacks.isEmpty()) {
+            boards = boardRepository.findRecommendProjectsAll(PageRequest.of(0, 3));
+        } else {
+            boards = boardRepository.findRecommendProjectsByTechStacks(
+                    boardTechStacks,
+                    PageRequest.of(0, 3)
+            );
+        }
+
+        return boards.stream()
+                .map(board -> boardConverter.toRecommendProjectDto(
+                        board,
+                        boardLikeRepository.countByBoard(board)
+                ))
+                .toList();
+    }
+
+    private List<root.git_turl.domain.board.enums.TechStack> convertToBoardTechStacks(Member member) {
+        return member.getInterestStacks()
+                .stream()
+                .flatMap(interestStack ->
+                        convertToBoardTechStacks(interestStack.getTechStack()).stream()
+                )
+                .distinct()
+                .toList();
+    }
+
+    private List<root.git_turl.domain.board.enums.TechStack> convertToBoardTechStacks(
+            root.git_turl.domain.member.enums.TechStack memberTechStack
+    ) {
+        return switch (memberTechStack) {
+            case PHP -> List.of(
+                    root.git_turl.domain.board.enums.TechStack.MYSQL,
+                    root.git_turl.domain.board.enums.TechStack.POSTGRESQL
+            );
+
+            case NODE_JS -> List.of(
+                    root.git_turl.domain.board.enums.TechStack.NODE_JS,
+                    root.git_turl.domain.board.enums.TechStack.EXPRESS,
+                    root.git_turl.domain.board.enums.TechStack.JAVASCRIPT
+            );
+
+            case NEST_JS -> List.of(
+                    root.git_turl.domain.board.enums.TechStack.NODE_JS,
+                    root.git_turl.domain.board.enums.TechStack.EXPRESS,
+                    root.git_turl.domain.board.enums.TechStack.TYPESCRIPT
+            );
+
+            case SPRING_BOOT -> List.of(
+                    root.git_turl.domain.board.enums.TechStack.SPRING_BOOT,
+                    root.git_turl.domain.board.enums.TechStack.SPRING,
+                    root.git_turl.domain.board.enums.TechStack.JAVA
+            );
+
+            case DJANGO -> List.of(
+                    root.git_turl.domain.board.enums.TechStack.MYSQL,
+                    root.git_turl.domain.board.enums.TechStack.POSTGRESQL
+            );
+
+            case REACT -> List.of(
+                    root.git_turl.domain.board.enums.TechStack.REACT,
+                    root.git_turl.domain.board.enums.TechStack.JAVASCRIPT,
+                    root.git_turl.domain.board.enums.TechStack.TYPESCRIPT
+            );
+
+            case TYPESCRIPT -> List.of(
+                    root.git_turl.domain.board.enums.TechStack.TYPESCRIPT,
+                    root.git_turl.domain.board.enums.TechStack.JAVASCRIPT,
+                    root.git_turl.domain.board.enums.TechStack.REACT,
+                    root.git_turl.domain.board.enums.TechStack.NEXT_JS
+            );
+
+            case KOTLIN -> List.of(
+                    root.git_turl.domain.board.enums.TechStack.JAVA,
+                    root.git_turl.domain.board.enums.TechStack.SPRING_BOOT
+            );
+
+            case SWIFT -> List.of(
+                    root.git_turl.domain.board.enums.TechStack.REACT,
+                    root.git_turl.domain.board.enums.TechStack.JAVASCRIPT
+            );
+
+            case JAVASCRIPT -> List.of(
+                    root.git_turl.domain.board.enums.TechStack.JAVASCRIPT,
+                    root.git_turl.domain.board.enums.TechStack.REACT,
+                    root.git_turl.domain.board.enums.TechStack.NODE_JS,
+                    root.git_turl.domain.board.enums.TechStack.EXPRESS
+            );
+
+            case ETC -> List.of(
+                    root.git_turl.domain.board.enums.TechStack.JAVASCRIPT,
+                    root.git_turl.domain.board.enums.TechStack.JAVA,
+                    root.git_turl.domain.board.enums.TechStack.NODE_JS
+            );
+        };
     }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- close #102

<br>

## 📝 작업 내용

### 구현 필수
- 추천 프로젝트 게시글 조회 API 구현
- 로그인한 사용자의 관심 기술스택 기반 추천 로직 적용
- 프로젝트 게시글의 구인스택과 사용자 관심 기술스택을 매칭
- 추천 결과는 랜덤 정렬 후 최대 3개 반환
- 추천 카드에 필요한 응답 필드 추가
  - 제목
  - 내용
  - 구인스택
  - 좋아요수
  - 조회수
  - 구인명수

### 기술 구현
- `BoardResDto.RecommendProjectDto` 추가
- `BoardQueryService`에 추천 프로젝트 조회 로직 추가
- `BoardRepository`에 추천 프로젝트 조회 쿼리 추가
- `BoardConverter`에 추천 프로젝트 응답 변환 메서드 추가
- `@CurrentUser`를 통해 로그인한 사용자 정보를 받아 추천 기준으로 사용
- 회원 관심 기술스택과 게시글 구인스택 enum 타입이 달라 Service 계층에서 매핑 처리
- 매칭 가능한 기술스택이 없을 경우 전체 프로젝트 게시글 기준으로 랜덤 추천

### 프로젝트 스택 매칭 기준
- 회원 관심 기술스택과 게시글 구인스택 enum 타입이 달라 Service 계층에서 1:N 매핑 처리
- 변환된 게시글 구인스택 중 하나라도 게시글의 `recruitStacks`와 일치하면 추천 대상에 포함
- 매칭 가능한 기술스택이 없을 경우 전체 프로젝트 게시글에서 랜덤 추천

| 회원 관심 기술스택 | 매칭되는 게시글 구인스택 |
|---|---|
| PHP | MYSQL, POSTGRESQL |
| NODE_JS | NODE_JS, EXPRESS, JAVASCRIPT |
| NEST_JS | NODE_JS, EXPRESS, TYPESCRIPT |
| SPRING_BOOT | SPRING_BOOT, SPRING, JAVA |
| DJANGO | MYSQL, POSTGRESQL |
| REACT | REACT, JAVASCRIPT, TYPESCRIPT |
| TYPESCRIPT | TYPESCRIPT, JAVASCRIPT, REACT, NEXT_JS |
| KOTLIN | JAVA, SPRING_BOOT |
| SWIFT | REACT, JAVASCRIPT |
| JAVASCRIPT | JAVASCRIPT, REACT, NODE_JS, EXPRESS |
| ETC | JAVASCRIPT, JAVA, NODE_JS |

<br>

## 🛠️ 기타
- 북마크 기능 논의 필요