### PR TITLE
[Fix] 커뮤니티 프로필 이미지 응답 추가

### DIFF
--- a/src/main/java/root/git_turl/domain/board/converter/BoardConverter.java
+++ b/src/main/java/root/git_turl/domain/board/converter/BoardConverter.java
@@ -76,6 +76,7 @@ public class BoardConverter {
                 .projectStacks(board.getProjectStacks())
 
                 .authorName(board.getMember().getNickname())
+                .profileImage(board.getMember().getProfileImage())
                 .views(board.getViews())
                 .likeCount(likeCount)
                 .isLiked(isLiked)

--- a/src/main/java/root/git_turl/domain/board/dto/BoardResDto.java
+++ b/src/main/java/root/git_turl/domain/board/dto/BoardResDto.java
@@ -45,6 +45,8 @@ public class BoardResDto {
 
         private String authorName;
 
+        private String profileImage;
+
         private Integer views;
 
         private Long likeCount;
@@ -141,10 +143,14 @@ public class BoardResDto {
     @Getter
     @Builder
     public static class RecommendProjectDto {
+
         private Long boardId;
+
         private String title;
         private String content;
+
         private List<TechStack> recruitStacks;
+
         private Long likeCount;
         private Integer views;
         private Integer recruitCount;

--- a/src/main/java/root/git_turl/domain/comment/converter/CommentConverter.java
+++ b/src/main/java/root/git_turl/domain/comment/converter/CommentConverter.java
@@ -89,6 +89,7 @@ public class CommentConverter {
                                     : "비밀 댓글입니다."
                 )
                 .writerName(comment.getMember().getNickname())
+                .profileImage(comment.getMember().getProfileImage())
                 .likeCount(likeCount)
                 .isLiked(isLiked)
                 .createdAt(comment.getCreatedAt())

--- a/src/main/java/root/git_turl/domain/comment/dto/CommentResDto.java
+++ b/src/main/java/root/git_turl/domain/comment/dto/CommentResDto.java
@@ -41,6 +41,7 @@ public class CommentResDto {
         private Boolean isDeleted;
         private String content;
         private String writerName;
+        private String profileImage;
         private Long likeCount;
         private Boolean isLiked;
         private LocalDateTime createdAt;


### PR DESCRIPTION
## 💡 관련 이슈
- close #114 

<br>

## 📝 작업 내용
- 게시글 상세 조회 시 작성자 프로필 이미지 응답 추가
- 댓글 조회 시 작성자 프로필 이미지 응답 추가

<br>
