### PR TITLE
[Feat] 좋아요 응답 필드 추가

### DIFF
--- a/src/main/java/root/git_turl/domain/board/controller/BoardLikeController.java
+++ b/src/main/java/root/git_turl/domain/board/controller/BoardLikeController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import root.git_turl.domain.board.code.BoardSuccessCode;
+import root.git_turl.domain.board.dto.BoardResDto;
 import root.git_turl.domain.board.service.BoardLikeCommandService;
 import root.git_turl.domain.member.entity.Member;
 import root.git_turl.domain.member.repository.MemberRepository;
@@ -19,30 +20,30 @@ public class BoardLikeController implements BoardLikeControllerDocs {
     private final BoardLikeCommandService boardLikeCommandService;
 
     @PostMapping("/{boardId}/likes")
-    public ApiResponse<Void> likeBoard(
+    public ApiResponse<BoardResDto.BoardLikeResultDto> likeBoard(
             @CurrentUser Member member,
             @PathVariable Long boardId
     ) {
-
-        boardLikeCommandService.likeBoard(member, boardId);
+        BoardResDto.BoardLikeResultDto result =
+                boardLikeCommandService.likeBoard(member, boardId);
 
         return ApiResponse.onSuccess(
                 BoardSuccessCode.BOARD_LIKE_CREATED,
-                null
+                result
         );
     }
 
     @DeleteMapping("/{boardId}/likes")
-    public ApiResponse<Void> unlikeBoard(
+    public ApiResponse<BoardResDto.BoardLikeResultDto> unlikeBoard(
             @CurrentUser Member member,
             @PathVariable Long boardId
     ) {
-
-        boardLikeCommandService.unlikeBoard(member, boardId);
+        BoardResDto.BoardLikeResultDto result =
+                boardLikeCommandService.unlikeBoard(member, boardId);
 
         return ApiResponse.onSuccess(
                 BoardSuccessCode.BOARD_LIKE_DELETED,
-                null
+                result
         );
     }
 }

--- a/src/main/java/root/git_turl/domain/board/controller/BoardLikeControllerDocs.java
+++ b/src/main/java/root/git_turl/domain/board/controller/BoardLikeControllerDocs.java
@@ -3,6 +3,7 @@ package root.git_turl.domain.board.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import org.springframework.web.bind.annotation.PathVariable;
+import root.git_turl.domain.board.dto.BoardResDto;
 import root.git_turl.domain.member.entity.Member;
 import root.git_turl.global.annotation.CurrentUser;
 import root.git_turl.global.apiPayload.ApiResponse;
@@ -13,7 +14,7 @@ public interface BoardLikeControllerDocs {
             summary = "게시글 좋아요",
             description = "게시글에 좋아요를 추가합니다."
     )
-    ApiResponse<Void> likeBoard(
+    ApiResponse<BoardResDto.BoardLikeResultDto> likeBoard(
             @CurrentUser @Parameter(hidden = true) Member member,
             @PathVariable Long boardId
     );
@@ -22,7 +23,7 @@ public interface BoardLikeControllerDocs {
             summary = "게시글 좋아요 취소",
             description = "게시글 좋아요를 취소합니다."
     )
-    ApiResponse<Void> unlikeBoard(
+    ApiResponse<BoardResDto.BoardLikeResultDto> unlikeBoard(
             @CurrentUser @Parameter(hidden = true) Member member,
             @PathVariable Long boardId
     );

--- a/src/main/java/root/git_turl/domain/board/dto/BoardResDto.java
+++ b/src/main/java/root/git_turl/domain/board/dto/BoardResDto.java
@@ -155,4 +155,11 @@ public class BoardResDto {
         private Integer views;
         private Integer recruitCount;
     }
+
+    @Getter
+    @Builder
+    public static class BoardLikeResultDto {
+        private Boolean isLiked;
+        private Long likeCount;
+    }
 }

--- a/src/main/java/root/git_turl/domain/board/service/BoardLikeCommandService.java
+++ b/src/main/java/root/git_turl/domain/board/service/BoardLikeCommandService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import root.git_turl.domain.board.code.BoardErrorCode;
+import root.git_turl.domain.board.dto.BoardResDto;
 import root.git_turl.domain.board.entity.Board;
 import root.git_turl.domain.board.entity.BoardLike;
 import root.git_turl.domain.board.exception.BoardException;
@@ -23,7 +24,7 @@ public class BoardLikeCommandService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public void likeBoard(Member currentMember, Long boardId) {
+    public BoardResDto.BoardLikeResultDto likeBoard(Member currentMember, Long boardId) {
 
         Member member = memberRepository.findById(currentMember.getId())
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
@@ -34,20 +35,23 @@ public class BoardLikeCommandService {
         boolean alreadyLiked =
                 boardLikeRepository.existsByBoardAndMember(board, member);
 
-        if (alreadyLiked) {
-            return;
+        if (!alreadyLiked) {
+            BoardLike boardLike = BoardLike.builder()
+                    .board(board)
+                    .member(member)
+                    .build();
+
+            boardLikeRepository.save(boardLike);
         }
 
-        BoardLike boardLike = BoardLike.builder()
-                .board(board)
-                .member(member)
+        return BoardResDto.BoardLikeResultDto.builder()
+                .isLiked(true)
+                .likeCount(boardLikeRepository.countByBoard(board))
                 .build();
-
-        boardLikeRepository.save(boardLike);
     }
 
     @Transactional
-    public void unlikeBoard(Member currentMember, Long boardId) {
+    public BoardResDto.BoardLikeResultDto unlikeBoard(Member currentMember, Long boardId) {
 
         Member member = memberRepository.findById(currentMember.getId())
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
@@ -59,10 +63,13 @@ public class BoardLikeCommandService {
                 boardLikeRepository.findByBoardAndMember(board, member)
                         .orElse(null);
 
-        if (boardLike == null) {
-            return;
+        if (boardLike != null) {
+            boardLikeRepository.delete(boardLike);
         }
 
-        boardLikeRepository.delete(boardLike);
+        return BoardResDto.BoardLikeResultDto.builder()
+                .isLiked(false)
+                .likeCount(boardLikeRepository.countByBoard(board))
+                .build();
     }
 }

--- a/src/main/java/root/git_turl/domain/comment/controller/CommentLikeController.java
+++ b/src/main/java/root/git_turl/domain/comment/controller/CommentLikeController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import root.git_turl.domain.comment.code.CommentSuccessCode;
+import root.git_turl.domain.comment.dto.CommentResDto;
 import root.git_turl.domain.comment.service.CommentLikeCommandService;
 import root.git_turl.domain.member.entity.Member;
 import root.git_turl.domain.member.repository.MemberRepository;
@@ -19,33 +20,33 @@ public class CommentLikeController implements CommentLikeControllerDocs {
     private final CommentLikeCommandService commentLikeCommandService;
 
 
-    @PostMapping("/comments/{commentId}/likes")
-    public ApiResponse<Void> likeComment(
+    @PostMapping("/{commentId}/likes")
+    public ApiResponse<CommentResDto.CommentLikeResultDto> likeComment(
             @CurrentUser Member member,
             @PathVariable Long commentId
     ) {
 
-
-        commentLikeCommandService.likeComment(member, commentId);
+        CommentResDto.CommentLikeResultDto result =
+                commentLikeCommandService.likeComment(member, commentId);
 
         return ApiResponse.onSuccess(
                 CommentSuccessCode.COMMENT_LIKE_CREATED,
-                null
+                result
         );
     }
 
-    @DeleteMapping("/comments/{commentId}/likes")
-    public ApiResponse<Void> unlikeComment(
+    @DeleteMapping("/{commentId}/likes")
+    public ApiResponse<CommentResDto.CommentLikeResultDto> unlikeComment(
             @CurrentUser Member member,
             @PathVariable Long commentId
     ) {
 
-
-        commentLikeCommandService.unlikeComment(member, commentId);
+        CommentResDto.CommentLikeResultDto result =
+                commentLikeCommandService.unlikeComment(member, commentId);
 
         return ApiResponse.onSuccess(
                 CommentSuccessCode.COMMENT_LIKE_DELETED,
-                null
+                result
         );
     }
 }

--- a/src/main/java/root/git_turl/domain/comment/controller/CommentLikeControllerDocs.java
+++ b/src/main/java/root/git_turl/domain/comment/controller/CommentLikeControllerDocs.java
@@ -3,6 +3,7 @@ package root.git_turl.domain.comment.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import org.springframework.web.bind.annotation.PathVariable;
+import root.git_turl.domain.comment.dto.CommentResDto;
 import root.git_turl.domain.member.entity.Member;
 import root.git_turl.global.annotation.CurrentUser;
 import root.git_turl.global.apiPayload.ApiResponse;
@@ -13,7 +14,7 @@ public interface CommentLikeControllerDocs {
             summary = "댓글 좋아요",
             description = "댓글에 좋아요를 추가합니다."
     )
-    ApiResponse<Void> likeComment(
+    ApiResponse<CommentResDto.CommentLikeResultDto> likeComment(
             @CurrentUser @Parameter(hidden = true) Member member,
             @PathVariable Long commentId
     );
@@ -22,7 +23,7 @@ public interface CommentLikeControllerDocs {
             summary = "댓글 좋아요 취소",
             description = "댓글 좋아요를 취소합니다."
     )
-    ApiResponse<Void> unlikeComment(
+    ApiResponse<CommentResDto.CommentLikeResultDto> unlikeComment(
             @CurrentUser @Parameter(hidden = true) Member member,
             @PathVariable Long commentId
     );

--- a/src/main/java/root/git_turl/domain/comment/dto/CommentResDto.java
+++ b/src/main/java/root/git_turl/domain/comment/dto/CommentResDto.java
@@ -80,4 +80,11 @@ public class CommentResDto {
         private Boolean isFirst;
         private Boolean isLast;
     }
+
+    @Getter
+    @Builder
+    public static class CommentLikeResultDto {
+        private Boolean isLiked;
+        private Long likeCount;
+    }
 }

--- a/src/main/java/root/git_turl/domain/comment/service/CommentLikeCommandService.java
+++ b/src/main/java/root/git_turl/domain/comment/service/CommentLikeCommandService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import root.git_turl.domain.comment.code.CommentErrorCode;
+import root.git_turl.domain.comment.dto.CommentResDto;
 import root.git_turl.domain.comment.entity.Comment;
 import root.git_turl.domain.comment.entity.CommentLike;
 import root.git_turl.domain.comment.exception.CommentException;
@@ -23,46 +24,58 @@ public class CommentLikeCommandService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public void likeComment(Member currentMember, Long commentId) {
+    public CommentResDto.CommentLikeResultDto likeComment(
+            Member currentMember,
+            Long commentId
+    ) {
 
         Member member = memberRepository.findById(currentMember.getId())
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
 
-        Comment comment = commentRepository.findByIdAndDeletedAtIsNull(commentId)
+        Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
 
         boolean alreadyLiked =
                 commentLikeRepository.existsByCommentAndMember(comment, member);
 
-        if (alreadyLiked) {
-            return;
+        if (!alreadyLiked) {
+            CommentLike commentLike = CommentLike.builder()
+                    .comment(comment)
+                    .member(member)
+                    .build();
+
+            commentLikeRepository.save(commentLike);
         }
 
-        CommentLike commentLike = CommentLike.builder()
-                .comment(comment)
-                .member(member)
+        return CommentResDto.CommentLikeResultDto.builder()
+                .isLiked(true)
+                .likeCount(commentLikeRepository.countByComment(comment))
                 .build();
-
-        commentLikeRepository.save(commentLike);
     }
 
     @Transactional
-    public void unlikeComment(Member currentMember, Long commentId) {
+    public CommentResDto.CommentLikeResultDto unlikeComment(
+            Member currentMember,
+            Long commentId
+    ) {
 
         Member member = memberRepository.findById(currentMember.getId())
                 .orElseThrow(() -> new MemberException(MemberErrorCode.NOT_FOUND));
 
-        Comment comment = commentRepository.findByIdAndDeletedAtIsNull(commentId)
+        Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
 
         CommentLike commentLike =
                 commentLikeRepository.findByCommentAndMember(comment, member)
                         .orElse(null);
 
-        if (commentLike == null) {
-            return;
+        if (commentLike != null) {
+            commentLikeRepository.delete(commentLike);
         }
 
-        commentLikeRepository.delete(commentLike);
+        return CommentResDto.CommentLikeResultDto.builder()
+                .isLiked(false)
+                .likeCount(commentLikeRepository.countByComment(comment))
+                .build();
     }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- close #120 

<br>

## 📝 작업 내용
- 게시글 좋아요/좋아요 취소 API 응답에 isLiked, likeCount 필드 추가
- 댓글 좋아요/좋아요 취소 API 응답에 isLiked, likeCount 필드 추가

<br>

## 🛠️ 기타
> 프론트에서 좋아요 상태 및 개수를 즉시 반영할 수 있도록 응답 스펙을 수정했습니다.
