### PR TITLE
[Fix] 추천 프로젝트 lazy loading session 문제

### DIFF
--- a/src/main/java/root/git_turl/domain/board/repository/BoardRecommendInterestStackRepository.java
+++ b/src/main/java/root/git_turl/domain/board/repository/BoardRecommendInterestStackRepository.java
@@ -1,0 +1,4 @@
+package root.git_turl.domain.board.repository;
+
+public interface BoardRecommendInterestStackRepository {
+}

--- a/src/main/java/root/git_turl/domain/board/repository/BoardRecommendInterestStackRepository.java
+++ b/src/main/java/root/git_turl/domain/board/repository/BoardRecommendInterestStackRepository.java
@@ -1,4 +1,12 @@
 package root.git_turl.domain.board.repository;
 
-public interface BoardRecommendInterestStackRepository {
+import org.springframework.data.jpa.repository.JpaRepository;
+import root.git_turl.domain.member.entity.InterestStack;
+
+import java.util.List;
+
+public interface BoardRecommendInterestStackRepository
+        extends JpaRepository<InterestStack, Long> {
+
+    List<InterestStack> findAllByMemberId(Long memberId);
 }

--- a/src/main/java/root/git_turl/domain/board/service/BoardRecommendService.java
+++ b/src/main/java/root/git_turl/domain/board/service/BoardRecommendService.java
@@ -6,11 +6,10 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import root.git_turl.domain.board.converter.BoardConverter;
 import root.git_turl.domain.board.dto.BoardResDto;
-import root.git_turl.domain.board.entity.Board;
 import root.git_turl.domain.board.enums.TechStack;
-import root.git_turl.domain.board.repository.BoardLikeRepository;
 import root.git_turl.domain.board.repository.BoardPreviewProjection;
 import root.git_turl.domain.board.repository.BoardRepository;
+import root.git_turl.domain.board.repository.BoardRecommendInterestStackRepository;
 import root.git_turl.domain.member.entity.InterestStack;
 import root.git_turl.domain.member.entity.Member;
 
@@ -21,8 +20,8 @@ import java.util.List;
 public class BoardRecommendService {
 
     private final BoardRepository boardRepository;
-    private final BoardLikeRepository boardLikeRepository;
     private final BoardConverter boardConverter;
+    private final BoardRecommendInterestStackRepository interestStackRepository;
 
     @Transactional(readOnly = true)
     public List<BoardResDto.RecommendProjectDto> getRecommendedProjects(
@@ -32,7 +31,7 @@ public class BoardRecommendService {
         PageRequest pageRequest = PageRequest.of(page, 10);
 
         List<TechStack> matchedStacks =
-                member.getInterestStacks().stream()
+                interestStackRepository.findAllByMemberId(member.getId()).stream()
                         .map(InterestStack::getTechStack)
                         .flatMap(stack -> convertToBoardTechStacks(stack).stream())
                         .distinct()


### PR DESCRIPTION
## 💡 관련 이슈
- close #123 

<br>

## 📝 작업 내용
- 추천 프로젝트 조회 시 발생하는 LazyInitializationException 수정
- 회원 관심 스택 조회 방식을 `member.getInterestStacks()`에서 Repository 직접 조회 방식으로 변경

<br>

## 🛠️ 기타
- 관심 스택을 별도 Repository를 통해 조회하도록 수정했습니다.
- Member 도메인 수정이 가능하다면 fetch join 기반 조회 방식으로 개선할 수 있습니다.