### PR TITLE
feat: 게시글/댓글 userId 응답 추가

### DIFF
--- a/src/main/java/root/git_turl/domain/board/converter/BoardConverter.java
+++ b/src/main/java/root/git_turl/domain/board/converter/BoardConverter.java
@@ -6,7 +6,6 @@ import root.git_turl.domain.board.dto.BoardReqDto;
 import root.git_turl.domain.board.dto.BoardResDto;
 import root.git_turl.domain.board.entity.Board;
 import root.git_turl.domain.board.enums.BoardType;
-import root.git_turl.domain.board.repository.BoardLikeRepository;
 import root.git_turl.domain.board.repository.BoardPreviewProjection;
 import root.git_turl.domain.member.entity.Member;
 
@@ -75,6 +74,7 @@ public class BoardConverter {
                 .recruitStacks(board.getRecruitStacks())
                 .projectStacks(board.getProjectStacks())
 
+                .writerId(board.getMember().getId())
                 .authorName(board.getMember().getNickname())
                 .profileImage(board.getMember().getProfileImage())
                 .views(board.getViews())

--- a/src/main/java/root/git_turl/domain/board/dto/BoardResDto.java
+++ b/src/main/java/root/git_turl/domain/board/dto/BoardResDto.java
@@ -43,6 +43,8 @@ public class BoardResDto {
 
         private List<PlatformType> platformTypes;
 
+        private Long writerId;
+
         private String authorName;
 
         private String profileImage;

--- a/src/main/java/root/git_turl/domain/comment/converter/CommentConverter.java
+++ b/src/main/java/root/git_turl/domain/comment/converter/CommentConverter.java
@@ -88,6 +88,7 @@ public class CommentConverter {
                                     ? comment.getContent()
                                     : "비밀 댓글입니다."
                 )
+                .writerId(comment.getMember().getId())
                 .writerName(comment.getMember().getNickname())
                 .profileImage(comment.getMember().getProfileImage())
                 .likeCount(likeCount)

--- a/src/main/java/root/git_turl/domain/comment/dto/CommentResDto.java
+++ b/src/main/java/root/git_turl/domain/comment/dto/CommentResDto.java
@@ -36,6 +36,7 @@ public class CommentResDto {
 
         private Long commentId;
         private Long parentId;
+        private Long writerId;
         private Integer depth;
         private Boolean isSecret;
         private Boolean isDeleted;


### PR DESCRIPTION
## 💡 관련 이슈
- close #135 

<br>

## 📝 작업 내용
> 게시글 상세 조회/댓글 목록 조회 응답에 userId(writerId) 포함

<br>

## 🛠️ 기타
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
