### PR TITLE
[Fix] 스택 조회 쿼리 수정

### DIFF
--- a/src/main/java/root/git_turl/domain/board/entity/Board.java
+++ b/src/main/java/root/git_turl/domain/board/entity/Board.java
@@ -3,6 +3,7 @@ package root.git_turl.domain.board.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import org.hibernate.annotations.BatchSize;
 import root.git_turl.domain.board.enums.*;
 import root.git_turl.global.entity.BaseEntity;
 import root.git_turl.domain.member.entity.Member;
@@ -68,6 +69,7 @@ public class Board extends BaseEntity {
     @Column(name = "project_status")
     private ProjectStatus projectStatus;
 
+    @BatchSize(size = 100)
     @ElementCollection(targetClass = TechStack.class)
     @Enumerated(EnumType.STRING)
     @CollectionTable(
@@ -78,6 +80,7 @@ public class Board extends BaseEntity {
     @Column(name = "recruit_stack")
     private List<TechStack> recruitStacks = new ArrayList<>();
 
+    @BatchSize(size = 100)
     @ElementCollection(targetClass = TechStack.class)
     @Enumerated(EnumType.STRING)
     @CollectionTable(
@@ -88,6 +91,7 @@ public class Board extends BaseEntity {
     @Column(name = "project_stack")
     private List<TechStack> projectStacks = new ArrayList<>();
 
+    @BatchSize(size = 100)
     @ElementCollection(targetClass = PlatformType.class)
     @Enumerated(EnumType.STRING)
     @CollectionTable(

--- a/src/main/java/root/git_turl/domain/board/repository/BoardRepository.java
+++ b/src/main/java/root/git_turl/domain/board/repository/BoardRepository.java
@@ -16,35 +16,28 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     @Query(
             value = """
-        SELECT b AS board, COUNT(DISTINCT bl.id) AS likeCount
-        FROM Board b
-        JOIN b.member m
-        LEFT JOIN b.recruitStacks rs
-        LEFT JOIN b.projectStacks ps
-        LEFT JOIN b.platformTypes pt
-        LEFT JOIN BoardLike bl ON bl.board = b
-        WHERE (:boardType IS NULL OR b.boardType = :boardType)
-          AND (:studyTag IS NULL OR b.studyTag = :studyTag)
-          AND (:projectStatus IS NULL OR b.projectStatus = :projectStatus)
-          AND (:recruitStack IS NULL OR rs = :recruitStack)
-          AND (:projectStack IS NULL OR ps = :projectStack)
-          AND (:platformType IS NULL OR pt = :platformType)
-        GROUP BY b
-        ORDER BY b.createdAt DESC
-    """,
+    SELECT b AS board, COUNT(DISTINCT bl.id) AS likeCount
+    FROM Board b
+    LEFT JOIN BoardLike bl ON bl.board = b
+    WHERE (:boardType IS NULL OR b.boardType = :boardType)
+      AND (:studyTag IS NULL OR b.studyTag = :studyTag)
+      AND (:projectStatus IS NULL OR b.projectStatus = :projectStatus)
+      AND (:recruitStack IS NULL OR :recruitStack MEMBER OF b.recruitStacks)
+      AND (:projectStack IS NULL OR :projectStack MEMBER OF b.projectStacks)
+      AND (:platformType IS NULL OR :platformType MEMBER OF b.platformTypes)
+    GROUP BY b
+    ORDER BY b.createdAt DESC
+""",
             countQuery = """
-        SELECT COUNT(DISTINCT b)
-        FROM Board b
-        LEFT JOIN b.recruitStacks rs
-        LEFT JOIN b.projectStacks ps
-        LEFT JOIN b.platformTypes pt
-        WHERE (:boardType IS NULL OR b.boardType = :boardType)
-          AND (:studyTag IS NULL OR b.studyTag = :studyTag)
-          AND (:projectStatus IS NULL OR b.projectStatus = :projectStatus)
-          AND (:recruitStack IS NULL OR rs = :recruitStack)
-          AND (:projectStack IS NULL OR ps = :projectStack)
-          AND (:platformType IS NULL OR pt = :platformType)
-    """
+    SELECT COUNT(DISTINCT b)
+    FROM Board b
+    WHERE (:boardType IS NULL OR b.boardType = :boardType)
+      AND (:studyTag IS NULL OR b.studyTag = :studyTag)
+      AND (:projectStatus IS NULL OR b.projectStatus = :projectStatus)
+      AND (:recruitStack IS NULL OR :recruitStack MEMBER OF b.recruitStacks)
+      AND (:projectStack IS NULL OR :projectStack MEMBER OF b.projectStacks)
+      AND (:platformType IS NULL OR :platformType MEMBER OF b.platformTypes)
+"""
     )
     Page<BoardPreviewProjection> findBoardListWithFiltersOrderByLatest(
             @Param("boardType") BoardType boardType,
@@ -58,35 +51,28 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     @Query(
             value = """
-        SELECT b AS board, COUNT(DISTINCT bl.id) AS likeCount
-        FROM Board b
-        JOIN b.member m
-        LEFT JOIN b.recruitStacks rs
-        LEFT JOIN b.projectStacks ps
-        LEFT JOIN b.platformTypes pt
-        LEFT JOIN BoardLike bl ON bl.board = b
-        WHERE (:boardType IS NULL OR b.boardType = :boardType)
-          AND (:studyTag IS NULL OR b.studyTag = :studyTag)
-          AND (:projectStatus IS NULL OR b.projectStatus = :projectStatus)
-          AND (:recruitStack IS NULL OR rs = :recruitStack)
-          AND (:projectStack IS NULL OR ps = :projectStack)
-          AND (:platformType IS NULL OR pt = :platformType)
-        GROUP BY b
-        ORDER BY COUNT(DISTINCT bl.id) DESC, b.createdAt DESC
-    """,
+    SELECT b AS board, COUNT(DISTINCT bl.id) AS likeCount
+    FROM Board b
+    LEFT JOIN BoardLike bl ON bl.board = b
+    WHERE (:boardType IS NULL OR b.boardType = :boardType)
+      AND (:studyTag IS NULL OR b.studyTag = :studyTag)
+      AND (:projectStatus IS NULL OR b.projectStatus = :projectStatus)
+      AND (:recruitStack IS NULL OR :recruitStack MEMBER OF b.recruitStacks)
+      AND (:projectStack IS NULL OR :projectStack MEMBER OF b.projectStacks)
+      AND (:platformType IS NULL OR :platformType MEMBER OF b.platformTypes)
+    GROUP BY b
+    ORDER BY COUNT(DISTINCT bl.id) DESC, b.createdAt DESC
+""",
             countQuery = """
-        SELECT COUNT(DISTINCT b)
-        FROM Board b
-        LEFT JOIN b.recruitStacks rs
-        LEFT JOIN b.projectStacks ps
-        LEFT JOIN b.platformTypes pt
-        WHERE (:boardType IS NULL OR b.boardType = :boardType)
-          AND (:studyTag IS NULL OR b.studyTag = :studyTag)
-          AND (:projectStatus IS NULL OR b.projectStatus = :projectStatus)
-          AND (:recruitStack IS NULL OR rs = :recruitStack)
-          AND (:projectStack IS NULL OR ps = :projectStack)
-          AND (:platformType IS NULL OR pt = :platformType)
-    """
+    SELECT COUNT(DISTINCT b)
+    FROM Board b
+    WHERE (:boardType IS NULL OR b.boardType = :boardType)
+      AND (:studyTag IS NULL OR b.studyTag = :studyTag)
+      AND (:projectStatus IS NULL OR b.projectStatus = :projectStatus)
+      AND (:recruitStack IS NULL OR :recruitStack MEMBER OF b.recruitStacks)
+      AND (:projectStack IS NULL OR :projectStack MEMBER OF b.projectStacks)
+      AND (:platformType IS NULL OR :platformType MEMBER OF b.platformTypes)
+"""
     )
     Page<BoardPreviewProjection> findBoardListWithFiltersOrderByLikeCount(
             @Param("boardType") BoardType boardType,
@@ -100,19 +86,15 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     @Query(
             value = """
-    SELECT DISTINCT b AS board, COUNT(DISTINCT bl.id) AS likeCount
+    SELECT b AS board, COUNT(DISTINCT bl.id) AS likeCount
     FROM Board b
-    JOIN b.member m
-    LEFT JOIN b.recruitStacks rs
-    LEFT JOIN b.projectStacks ps
-    LEFT JOIN b.platformTypes pt
     LEFT JOIN BoardLike bl ON bl.board = b
     WHERE b.member.id = :memberId
     GROUP BY b
     ORDER BY b.createdAt DESC
 """,
             countQuery = """
-    SELECT COUNT(DISTINCT b)
+    SELECT COUNT(b)
     FROM Board b
     WHERE b.member.id = :memberId
 """
@@ -130,8 +112,8 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     LEFT JOIN BoardLike bl ON bl.board = b
     WHERE b.boardType = root.git_turl.domain.board.enums.BoardType.PROJECT
       AND (
-          rs IN :techStacks
-          OR ps IN :techStacks
+          rs IN (:techStacks)
+          OR ps IN (:techStacks)
       )
     GROUP BY b
     ORDER BY b.createdAt DESC


### PR DESCRIPTION
## 💡 관련 이슈
- close #127 

<br>

## 📝 작업 내용
- 게시글 목록 조회 성능 개선
- 다중 스택/플랫폼 JOIN 쿼리를 최적화하여 조회 부하 감소
- `@BatchSize` 적용으로 N+1 문제 완화

<br>

## 🛠️ 기타
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
