### PR TITLE
refactor: 로그인 시 이메일 업데이트 삭제, 커밋 통계 서버에서 추가 저장 #154

### DIFF
--- a/src/main/java/root/git_turl/domain/member/entity/Member.java
+++ b/src/main/java/root/git_turl/domain/member/entity/Member.java
@@ -81,10 +81,9 @@ public class Member extends BaseEntity {
         interestStack.assignMember(this);
     }
 
-    public void updateGithubInfo(String githubId, String githubName, String email) {
+    public void updateGithubInfo(String githubId, String githubName) {
         this.githubId = githubId;
         this.githubName = githubName;
-        this.email = email;
     }
 
     public void updateProfileImage(String profileImage) {

--- a/src/main/java/root/git_turl/domain/report/service/ReportAsyncService.java
+++ b/src/main/java/root/git_turl/domain/report/service/ReportAsyncService.java
@@ -15,6 +15,7 @@ import root.git_turl.domain.report.dto.GitAnalysisResult;
 import root.git_turl.domain.report.dto.ProblemList;
 import root.git_turl.domain.report.dto.ReportSavedEvent;
 import root.git_turl.domain.report.dto.commit.GitCommit;
+import root.git_turl.domain.report.dto.reportDetail.CommitStats;
 import root.git_turl.domain.report.dto.reportDetail.ReportWrapper;
 import root.git_turl.domain.report.entity.Report;
 import root.git_turl.domain.report.enums.GenerationStatus;
@@ -73,13 +74,19 @@ public class ReportAsyncService {
             List<GitCommit> userCommits = commits.stream()
                     .filter(c -> c.getAuthorEmail().equals(email) || c.getAuthorEmail().contains(event.githubId()))
                     .toList();
-
             GitAnalysisResult result = gitAnalysisService.analyze(GitRepoParser.getRepoFullName(gitUrl), repoPath, commits, userCommits);
 
             String problemPrompt = buildProblemPrompt.buildReportProblemPrompt(result);
             ProblemList extractedProblems = gptService.makeReportProblem(problemPrompt);
             String prompt = buildPrompt.buildReportPrompt(result, event.githubId(), extractedProblems);
             ReportWrapper content = getContent(prompt);
+            content.getContent().setCommitStats(
+                    new CommitStats(
+                            result.getTotalCommits(),
+                            result.getUserTotalCommits(),
+                            result.getContributionRate()
+                    )
+            );
             String contentJson;
 
             try {

--- a/src/main/java/root/git_turl/global/security/oauth/CustomOAuthService.java
+++ b/src/main/java/root/git_turl/global/security/oauth/CustomOAuthService.java
@@ -33,12 +33,11 @@ public class CustomOAuthService extends DefaultOAuth2UserService {
         String socialUid = String.valueOf(attributes.get("id"));
         String login = (String) attributes.get("login");
         String profileImage = (String) attributes.get("avatar_url");
-        String email = (String) attributes.get("email");
         String name = (String) attributes.get("name");
 
         return memberRepository.findBySocialUid(socialUid)
                 .map(m -> {
-                    m.updateGithubInfo(login, name, email);
+                    m.updateGithubInfo(login, name);
                     if (m.getStatus().equals(Status.INACTIVATE)) {
                         if (m.getDeletedAt().plusDays(7).isAfter(LocalDateTime.now())) {
                             m.activateMember();
@@ -52,7 +51,6 @@ public class CustomOAuthService extends DefaultOAuth2UserService {
                             .socialUid(socialUid)
                             .githubId(login)
                             .profileImage(profileImage)
-                            .email(email)
                             .githubName(name)
                             .status(Status.ACTIVATE)
                             .build();

--- a/src/main/java/root/git_turl/global/util/prompt/BuildPrompt.java
+++ b/src/main/java/root/git_turl/global/util/prompt/BuildPrompt.java
@@ -140,20 +140,6 @@ public class BuildPrompt {
         - purpose: 프로젝트 목적을 2~3문장으로 구체적으로 설명.
 
         - stack: diff에서 확인된 실제 기술 스택만 작성. 추측 금지.
-
-        - commitStats: 위 commitContribution 데이터 합산으로 totalCommits 계산.
-                - commitStats:
-                  totalCommits는 반드시 위 totalCommits 값을 그대로 사용한다.
-                  myCommits는 반드시 위 myCommits 값을 그대로 사용한다.
-                  myCommitRate는 반드시 위 myCommitRate 값을 그대로 사용한다.
-                  commitContribution을 이용해 재계산하지 마라.
-                  다른 값으로 변환하지 마라.
-                  퍼센트 값은 이미 계산된 값이다.
-                ""\".formatted(
-                        result.getTotalCommits(),
-                        result.getUserTotalCommits(),
-                        result.getContributionRate()
-                ));
         
         - commitContribution: 위 [commitContribution] 데이터의 키-값을 그대로 복사.
           절대 추측하거나 변형하지 마라.

--- a/src/test/java/root/git_turl/GitLogTest.java
+++ b/src/test/java/root/git_turl/GitLogTest.java
@@ -58,16 +58,16 @@ public class GitLogTest {
             System.out.println("\ndiffs: ");
             result.getMajorCommits().forEach(System.out::println);
 
-        String prompt = buildPrompt.buildReportPrompt(result, githubName);
-
-        try {
-            Files.writeString(
-                    Path.of("prompt.txt"),
-                    prompt,
-                    StandardCharsets.UTF_8
-            );
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+//        String prompt = buildPrompt.buildReportPrompt(result, githubName);
+//
+//        try {
+//            Files.writeString(
+//                    Path.of("prompt.txt"),
+//                    prompt,
+//                    StandardCharsets.UTF_8
+//            );
+//        } catch (IOException e) {
+//            throw new RuntimeException(e);
+//        }
     }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- close #154

<br>

## 📝 작업 내용
1. 이메일 정보 저장
기존 방식: 회원 가입 시 이메일을 다른 api로 추가로 얻어 저장하기
기존 방법의 문제점: 소셜 로그인 시 매번 이메일을 업데이트 하나, oauth에서는 이메일을 추출 못 해서 늘 null로 덧씌워짐
-> 해당 부분 수정

2. gpt 프롬프트로 통계 내기
저장할 리포트 정보 json을 gpt에게 일임 -> 통계 부분은 서버에서 추가로 덧씌우도록 수정
<br>

## 🛠️ 기타
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
