### PR TITLE
fix: 로그인 api 구현, 프론트 리다이렉트 경로 파라미터로 설정 #167

### DIFF
--- a/src/main/java/root/git_turl/domain/member/controller/AuthController.java
+++ b/src/main/java/root/git_turl/domain/member/controller/AuthController.java
@@ -2,6 +2,7 @@ package root.git_turl.domain.member.controller;
 
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -13,6 +14,8 @@ import root.git_turl.domain.member.service.TokenService;
 import root.git_turl.global.annotation.CurrentUser;
 import root.git_turl.global.apiPayload.ApiResponse;
 
+import java.io.IOException;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
@@ -21,6 +24,18 @@ public class AuthController implements AuthControllerDocs{
 
     private final TokenService tokenService;
     private final MemberService memberService;
+
+    @GetMapping("/login/github")
+    public void githubLogin(
+            @RequestParam("redirect_uri") String redirectUri,
+            HttpServletRequest request,
+            HttpServletResponse response
+    ) throws IOException {
+
+        request.getSession().setAttribute("redirect_uri", redirectUri);
+
+        response.sendRedirect("/oauth2/authorization/github");
+    }
 
     @PostMapping("/reissue")
     public ApiResponse<TokenDto.AccessToken> accessTokenReissue(

--- a/src/main/java/root/git_turl/global/config/SecurityConfig.java
+++ b/src/main/java/root/git_turl/global/config/SecurityConfig.java
@@ -35,6 +35,7 @@ public class SecurityConfig {
             "/api/v1/members/*/profile",
             "/api/v1/auth/reissue",
             "/api/v1/auth/logout",
+            "/api/v1/auth/login/github",
             "/login/**",
     };
 
@@ -80,6 +81,8 @@ public class SecurityConfig {
 
         // 프론트엔드 주소 허용
         configuration.addAllowedOrigin("https://git-turl.vercel.app");
+        configuration.addAllowedOrigin("http://localhost:5173");
+        configuration.addAllowedOrigin("https://localhost:5173");
 
         // 허용할 헤더와 메서드
         configuration.addAllowedHeader("*");

--- a/src/main/java/root/git_turl/global/security/oauth/OAuthSuccessHandler.java
+++ b/src/main/java/root/git_turl/global/security/oauth/OAuthSuccessHandler.java
@@ -62,10 +62,21 @@ public class OAuthSuccessHandler implements AuthenticationSuccessHandler {
 
         CookieUtil.addCookie(response, "refreshToken", refreshToken);
 
-        if (oAuthMember.isNew()) {
-            response.sendRedirect(BASE_URL + "/login/loading?route=signup&token=" + accessToken);
-        } else {
-            response.sendRedirect(BASE_URL + "/login/loading?route=home&token=" + accessToken);
+        String redirectUri = (String) request.getSession().getAttribute("redirect_uri");
+
+        if (redirectUri != null) {
+            if (oAuthMember.isNew()) {
+                response.sendRedirect(redirectUri + "/login/loading?route=signup&token=" + accessToken);
+            } else {
+                response.sendRedirect(redirectUri + "/login/loading?route=home&token=" + accessToken);
+            }
+        }
+        else {
+            if (oAuthMember.isNew()) {
+                response.sendRedirect(BASE_URL + "/login/loading?route=signup&token=" + accessToken);
+            } else {
+                response.sendRedirect(BASE_URL + "/login/loading?route=home&token=" + accessToken);
+            }
         }
     }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- close #167

<br>

## 📝 작업 내용
프론트에서 로컬+배포 경로 모두 로그인이 가능하도록 설계 변경
- 기존 방식
프론트에서 oauth 로그인 경로로 리다이렉트 -> 백에서 프론트 경로(1개만 설정 가능)로 리다이렉트 
- 바뀐 방식
프론트에서 프론트 리다이렉트 경로와 함께 로그인 api로 리다이렉트(get 요청) -> 백에서 해당 경로에 맞게 리다이렉트

<br>

## 🛠️ 기타
> 작업의 특이사항 또는 리뷰어가 특별히 봐주었으면 하는 부분을 작성해주세요.
