### PR TITLE
[Feat] 게시글 목록 댓글 수 응답 추가

### DIFF
--- a/src/main/java/root/git_turl/domain/board/converter/BoardConverter.java
+++ b/src/main/java/root/git_turl/domain/board/converter/BoardConverter.java
@@ -107,7 +107,8 @@ public class BoardConverter {
 
     public static BoardResDto.BoardPreviewDto toBoardPreviewDto(
             Board board,
-            Long likeCount
+            Long likeCount,
+            Long commentCount
     ) {
         return BoardResDto.BoardPreviewDto.builder()
                 .boardId(board.getId())
@@ -132,6 +133,7 @@ public class BoardConverter {
 
                 .writerName(board.getMember().getNickname())
                 .likeCount(likeCount)
+                .commentCount(commentCount)
                 .createdAt(board.getCreatedAt())
                 .build();
     }
@@ -142,7 +144,8 @@ public class BoardConverter {
         List<BoardResDto.BoardPreviewDto> boardList = boardPage.stream()
                 .map(p -> toBoardPreviewDto(
                         p.getBoard(),
-                        p.getLikeCount()
+                        p.getLikeCount(),
+                        p.getCommentCount()
                 ))
                 .toList();
 

--- a/src/main/java/root/git_turl/domain/board/dto/BoardResDto.java
+++ b/src/main/java/root/git_turl/domain/board/dto/BoardResDto.java
@@ -122,6 +122,8 @@ public class BoardResDto {
 
         private Long likeCount;
 
+        private Long commentCount;
+
         private LocalDateTime createdAt;
     }
 

--- a/src/main/java/root/git_turl/domain/board/repository/BoardRecommendProjection.java
+++ b/src/main/java/root/git_turl/domain/board/repository/BoardRecommendProjection.java
@@ -2,8 +2,7 @@ package root.git_turl.domain.board.repository;
 
 import root.git_turl.domain.board.entity.Board;
 
-public interface BoardPreviewProjection {
+public interface BoardRecommendProjection {
     Board getBoard();
     Long getLikeCount();
-    Long getCommentCount();
 }

--- a/src/main/java/root/git_turl/domain/board/repository/BoardRepository.java
+++ b/src/main/java/root/git_turl/domain/board/repository/BoardRepository.java
@@ -16,9 +16,12 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     @Query(
             value = """
-    SELECT b AS board, COUNT(DISTINCT bl.id) AS likeCount
+    SELECT b AS board,
+      COUNT(DISTINCT bl.id) AS likeCount,
+      COUNT(DISTINCT c.id) AS commentCount
     FROM Board b
     LEFT JOIN BoardLike bl ON bl.board = b
+    LEFT JOIN Comment c ON c.board = b AND c.deletedAt IS NULL
     WHERE (:boardType IS NULL OR b.boardType = :boardType)
       AND (:studyTag IS NULL OR b.studyTag = :studyTag)
       AND (:projectStatus IS NULL OR b.projectStatus = :projectStatus)
@@ -51,9 +54,12 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     @Query(
             value = """
-    SELECT b AS board, COUNT(DISTINCT bl.id) AS likeCount
+    SELECT b AS board,
+      COUNT(DISTINCT bl.id) AS likeCount,
+      COUNT(DISTINCT c.id) AS commentCount
     FROM Board b
     LEFT JOIN BoardLike bl ON bl.board = b
+    LEFT JOIN Comment c ON c.board = b AND c.deletedAt IS NULL
     WHERE (:boardType IS NULL OR b.boardType = :boardType)
       AND (:studyTag IS NULL OR b.studyTag = :studyTag)
       AND (:projectStatus IS NULL OR b.projectStatus = :projectStatus)
@@ -86,9 +92,12 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
 
     @Query(
             value = """
-    SELECT b AS board, COUNT(DISTINCT bl.id) AS likeCount
+    SELECT b AS board,
+      COUNT(DISTINCT bl.id) AS likeCount,
+      COUNT(DISTINCT c.id) AS commentCount
     FROM Board b
     LEFT JOIN BoardLike bl ON bl.board = b
+    LEFT JOIN Comment c ON c.board = b AND c.deletedAt IS NULL
     WHERE b.member.id = :memberId
     GROUP BY b
     ORDER BY b.createdAt DESC
@@ -118,7 +127,7 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     GROUP BY b
     ORDER BY b.createdAt DESC
 """)
-    List<BoardPreviewProjection> findRecommendedProjectsByTechStacks(
+    List<BoardRecommendProjection> findRecommendedProjectsByTechStacks(
             @Param("techStacks") List<TechStack> techStacks,
             Pageable pageable
     );
@@ -131,5 +140,5 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     GROUP BY b
     ORDER BY FUNCTION('RAND')
 """)
-    List<BoardPreviewProjection> findRandomProjects(Pageable pageable);
+    List<BoardRecommendProjection> findRandomProjects(Pageable pageable);
 }

--- a/src/main/java/root/git_turl/domain/board/service/BoardRecommendService.java
+++ b/src/main/java/root/git_turl/domain/board/service/BoardRecommendService.java
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import root.git_turl.domain.board.converter.BoardConverter;
 import root.git_turl.domain.board.dto.BoardResDto;
 import root.git_turl.domain.board.enums.TechStack;
-import root.git_turl.domain.board.repository.BoardPreviewProjection;
+import root.git_turl.domain.board.repository.BoardRecommendProjection;
 import root.git_turl.domain.board.repository.BoardRepository;
 import root.git_turl.domain.board.repository.BoardRecommendInterestStackRepository;
 import root.git_turl.domain.member.entity.InterestStack;
@@ -37,7 +37,7 @@ public class BoardRecommendService {
                         .distinct()
                         .toList();
 
-        List<BoardPreviewProjection> boards;
+        List<BoardRecommendProjection> boards;
 
         if (matchedStacks.isEmpty()) {
             boards = boardRepository.findRandomProjects(pageRequest);


### PR DESCRIPTION
## 💡 관련 이슈
- close #172 

<br>

## 📝 작업 내용
- 게시글 목록 조회 응답에 commentCount 필드 추가
- 게시글 목록/내 게시글 조회 쿼리에 댓글 수 집계 로직 추가
- 목록용/추천용 Projection 분리 (BoardPreviewProjection, BoardRecommendProjection)
- Converter 및 DTO 수정

<br>

## 🛠️ 기타
- soft delete 된 댓글(deletedAt != null)은 댓글 수 집계에서 제외되도록 처리했습니다.